### PR TITLE
Fix reset of settings

### DIFF
--- a/dbt/adapters/dremio/connections.py
+++ b/dbt/adapters/dremio/connections.py
@@ -58,8 +58,7 @@ class DremioCredentials(Credentials):
     def _connection_keys(self):
         # return an iterator of keys to pretty-print in 'dbt debug'
         # raise NotImplementedError
-        return 'driver', 'host', 'port', 'UID', 'database', 'schema', 
-        'additional_parameters', 'datalake', 'root_path', 'environment', 'use_ssl'
+        return 'driver', 'host', 'port', 'UID', 'database', 'schema', 'additional_parameters', 'datalake', 'root_path', 'environment', 'use_ssl'
 
     @classmethod
     def __pre_deserialize__(cls, data):
@@ -128,7 +127,6 @@ class DremioConnectionManager(SQLConnectionManager):
             return connection
 
         credentials = connection.credentials
-        logger.debug(credentials.pat)
 
         try:
             con_str = ["ConnectionType=Direct", "AuthenticationType=Plain", "QueryTimeout=600"]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        'dbt-core==1.2.2',
+        'dbt-core==1.1.2',
         'pyodbc>=4.0.27',
     ]
 )


### PR DESCRIPTION
A silly bug ended up resetting the database and schema settings, preventing the test models from running.

Also reverted dbt-core version to 1.1.2 after profile_template stopper working again on dbt-core 1.2.2.