### PR TITLE
Updates to support upload distribution to PyPI

### DIFF
--- a/dbt/adapters/dremio/__version__.py
+++ b/dbt/adapters/dremio/__version__.py
@@ -1,1 +1,1 @@
-version = "1.1.0b"
+version = "1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 from setuptools import find_namespace_packages, setup
 
 package_name = "dbt-dremio"
-package_version = "1.1.0b"
+package_version = "1.1.0"
 description = """The Dremio adapter plugin for dbt"""
 
 setup(


### PR DESCRIPTION
Required the "b" to be dropped in the versionso that it would be installed by PyPi.

Added toml file as required by twine.