### PR TITLE
Resolve hitting endpoint too many times

### DIFF
--- a/dbt/adapters/dremio/api/basic.py
+++ b/dbt/adapters/dremio/api/basic.py
@@ -19,8 +19,6 @@ import requests
 from dbt.adapters.dremio.api.parameters import Parameters
 from dbt.adapters.dremio.api.authentication import DremioPatAuthentication
 from dbt.adapters.dremio.api.url_builder import UrlBuilder
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 
 def login(api_parameters: Parameters, timeout=10, verify=True):
@@ -30,15 +28,10 @@ def login(api_parameters: Parameters, timeout=10, verify=True):
 
     url = UrlBuilder.login_url(api_parameters.base_url)
 
-    session = requests.Session()
-    retry = Retry(connect=3, backoff_factor=0.5)
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount('http://', adapter)
-    session.mount('https://', adapter)
-
-    r = session.post(url, json={"userName": api_parameters.authentication.username, "password": api_parameters.authentication.password}, timeout=timeout, verify=verify)
+    r = requests.post(url, json={"userName": api_parameters.authentication.username, "password": api_parameters.authentication.password}, timeout=timeout, verify=verify)
     r.raise_for_status()
-    
+
     api_parameters.authentication.token = r.json()["token"]
 
     return api_parameters
+

--- a/dbt/adapters/dremio/api/basic.py
+++ b/dbt/adapters/dremio/api/basic.py
@@ -19,8 +19,9 @@ import requests
 from dbt.adapters.dremio.api.parameters import Parameters
 from dbt.adapters.dremio.api.authentication import DremioPatAuthentication
 from dbt.adapters.dremio.api.url_builder import UrlBuilder
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
-import json
 
 def login(api_parameters: Parameters, timeout=10, verify=True):
 
@@ -29,7 +30,13 @@ def login(api_parameters: Parameters, timeout=10, verify=True):
 
     url = UrlBuilder.login_url(api_parameters.base_url)
 
-    r = requests.post(url, json={"userName": api_parameters.authentication.username, "password": api_parameters.authentication.password}, timeout=timeout, verify=verify)
+    session = requests.Session()
+    retry = Retry(connect=3, backoff_factor=0.5)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+
+    r = session.post(url, json={"userName": api_parameters.authentication.username, "password": api_parameters.authentication.password}, timeout=timeout, verify=verify)
     r.raise_for_status()
     
     api_parameters.authentication.token = r.json()["token"]

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from tests.functional.adapter.utils.test_utils import (
     relation_from_name,
     check_relations_equal,
@@ -38,6 +39,12 @@ sources:
       - name: seed
         identifier: "{{ var('seed_name', 'base') }}"
 """
+
+
+@pytest.fixture(autouse=True)
+def slow_down_tests():
+    yield
+    time.sleep(1)
 
 
 class TestSimpleMaterializationsDremio(BaseSimpleMaterializations):

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -40,9 +40,9 @@ sources:
         identifier: "{{ var('seed_name', 'base') }}"
 """
 
-
+# Login endpoint is being hit too many times
 @pytest.fixture(autouse=True)
-def slow_down_tests():
+def throttle_login_connections():
     yield
     time.sleep(1)
 


### PR DESCRIPTION
### Summary

When running the tests consecutively, the login endpoint is hit too many times, resulting in a connection error. To resolve this we've added a delay between the tests.

### Description

Added a fixture that's autoused by the tests to sleep 1 second in between each tests.

### Related Issue

https://github.com/dremio/dbt-dremio/issues/22

### Additional Reviewers
@jlarue26 
@argusli