### PR TITLE
Add script for manual tests

### DIFF
--- a/.github/scripts/smoke_test.sh
+++ b/.github/scripts/smoke_test.sh
@@ -1,0 +1,78 @@
+#! /bin/bash
+
+# Software test
+test_software() {
+cd ../../.. && \
+if [ -d "./$project" ]; then
+    rm -r $project
+fi
+dbt init -s $project && \
+{ cat > ./.dbt/profiles.yml << EOF
+$project:
+  outputs:
+    dev:
+      password: $test_password
+      port: 9047
+      software_host: $test_host
+      threads: 1
+      type: dremio
+      use_ssl: false
+      user: $test_user
+  target: dev
+EOF
+} && \
+
+cd $project/ && \
+dbt debug && \
+dbt run
+
+}
+
+#Cloud test
+test_cloud() {
+cd ../../.. && \
+if [ -d "./$project" ]; then
+    rm -r $project
+fi
+dbt init -s $project && \
+{ cat > ./.dbt/profiles.yml << EOF
+$project:
+  outputs:
+    dev:
+      cloud_host: $test_host
+      cloud_project_id: $test_cloud_project
+      pat: $test_token
+      threads: 1
+      type: dremio
+      use_ssl: true
+      user: $test_user
+  target: dev
+EOF
+} && \
+echo 'vars:' >> ./$project/dbt_project.yml && \
+echo '  dremio:reflections_enabled: false' >> ./$project/dbt_project.yml && \
+
+cd $project/ && \
+dbt debug && \
+dbt run 
+}
+
+# Main
+test_type=$1
+
+if [ $test_type == software ]; then 
+    test_user=$2
+    test_password=$3
+    test_host=$4
+    test_port=$5
+    project=software_proj
+    test_software
+elif [ $test_type == cloud ]; then
+    test_user=$2
+    test_token=$3
+    test_host=$4
+    test_cloud_project=$5
+    project=cloud_proj
+    test_cloud
+fi
+


### PR DESCRIPTION
### Summary

Created a script to automate the manual smoke test we were doing before merging PRs. Next step is to call this using a github workflow so that we can automate testing as soon as a PR is created. 

### Description

Created a script which takes profiles.yml options as parameters. Another option is specified to decide if we're testing against software or cloud. These parameters will be fixed in our workflow, so no need to memorize the order of them to run the script manually. 

### Related Issue

https://github.com/dremio/dbt-dremio/issues/35

### Additional Reviewers

@ArgusLi 
@jlarue26 