### PR TITLE
Make dremio:reflections_enabled default to false if not declared.

### DIFF
--- a/dbt/include/dremio/macros/adapters/metadata.sql
+++ b/dbt/include/dremio/macros/adapters/metadata.sql
@@ -25,7 +25,7 @@ limitations under the License.*/
 
     with cte as (
 
-    {%- if var('dremio:reflections_enabled', false) %}
+    {%- if var('dremio:reflections_enabled', default=false) %}
 
       select
         case when position('.' in table_schema) > 0
@@ -140,7 +140,7 @@ limitations under the License.*/
         + (('.' + schema) if schema != 'no_schema' else '') -%}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
 
-    {%- if var('dremio:reflections_enabled', false) -%}
+    {%- if var('dremio:reflections_enabled', default=false) -%}
 
       with cte1 as (
         select

--- a/dbt/include/dremio/macros/adapters/metadata.sql
+++ b/dbt/include/dremio/macros/adapters/metadata.sql
@@ -25,7 +25,7 @@ limitations under the License.*/
 
     with cte as (
 
-    {%- if var('dremio:reflections_enabled', true) %}
+    {%- if var('dremio:reflections_enabled', false) %}
 
       select
         case when position('.' in table_schema) > 0
@@ -140,7 +140,7 @@ limitations under the License.*/
         + (('.' + schema) if schema != 'no_schema' else '') -%}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
 
-    {%- if var('dremio:reflections_enabled', true) -%}
+    {%- if var('dremio:reflections_enabled', false) -%}
 
       with cte1 as (
         select

--- a/dbt/include/dremio/macros/materializations/reflection/reflection.sql
+++ b/dbt/include/dremio/macros/materializations/reflection/reflection.sql
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.*/
 
 {% materialization reflection, adapter='dremio' %}
-  {%- if not  var('dremio:reflections_enabled', true)  -%}
+  {%- if not  var('dremio:reflections_enabled', false)  -%}
     {% do exceptions.raise_compiler_error("reflections are disabled, set 'dremio:reflections_enabled' variable to true to enable them") %}
   {%- endif -%}
 

--- a/dbt/include/dremio/macros/materializations/reflection/reflection.sql
+++ b/dbt/include/dremio/macros/materializations/reflection/reflection.sql
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.*/
 
 {% materialization reflection, adapter='dremio' %}
-  {%- if not  var('dremio:reflections_enabled', false)  -%}
+  {%- if not  var('dremio:reflections_enabled', default=false)  -%}
     {% do exceptions.raise_compiler_error("reflections are disabled, set 'dremio:reflections_enabled' variable to true to enable them") %}
   {%- endif -%}
 


### PR DESCRIPTION
### Summary

Make dremio:reflections_enabled default to false if not declared.

### Description

dremio:reflections_enabled will now default to false. We expect most users to have accounts without admin privileges. Since listing reflections requires admin privileges, the default should be to disable reflections, with admins having to enable them if needed.

### Related Issue

#18 

### Additional Reviewers

@jlarue26 @ravjotbrar 