### PR TITLE
Fix type_string returning string instead of varchar

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,10 +6,14 @@
 
 <!--- Details of what you changed -->
 
+### Test Results
+
+<!--- Details of the tests you've ran -->
+
+### Changelog
+
+-   [ ] Added a summary of what this PR accomplishes to CHANGELOG.md
+
 ### Related Issue
 
 <!--- Link to issue where this is tracked -->
-
-### Additional Reviewers
-
-<!--- Add reviewers -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixes
 
--   Override dbt-core default\_\_type_string() macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
+-   Override dbt-core `default\_\_type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
 
 ## Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# dbt-dremio 1.3.1 - release tbd
+
+## Features
+
+## Fixes
+
+-   Override dbt-core default\_\_type_string() macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
+
+## Under the Hood
+
+## Dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixes
 
--   Override dbt-core `default\_\_type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
+-   Override dbt-core `default__type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
 
 ## Under the Hood
 

--- a/dbt/include/dremio/macros/utils/data_types.sql
+++ b/dbt/include/dremio/macros/utils/data_types.sql
@@ -1,0 +1,3 @@
+{% macro dremio__type_string() %}
+    {{ return(api.Column.translate_type("VARCHAR")) }}
+{% endmacro %}

--- a/tests/functional/adapter/grants/test_snapshot_grants.py
+++ b/tests/functional/adapter/grants/test_snapshot_grants.py
@@ -20,7 +20,7 @@ from tests.functional.adapter.grants.base_grants import BaseGrantsDremio
 from tests.functional.adapter.utils.test_utils import relation_from_name, DATALAKE
 from dbt.tests.util import get_connection
 
-# Override this model to use strategy timestamp and to cast as VARCHAR
+# Override this model to use strategy timestamp
 # we use timestamp for now, as 'check' is not supported
 my_snapshot_sql = """
 {% snapshot my_snapshot %}
@@ -28,7 +28,7 @@ my_snapshot_sql = """
         updated_at='id', unique_key='id', strategy='timestamp',
         target_database=database, target_schema=schema
     ) }}
-    select 1 as id, cast('blue' as VARCHAR) as color
+    select 1 as id, cast('blue' as {{ type_string() }}) as color
 {% endsnapshot %}
 """.strip()
 


### PR DESCRIPTION
### Summary

Fix type_string return string instead of varchar

### Description

`dremio__type_string()` macro overrides the dbt-core `default__type_string()` macro to use the Dremio supported VARCHAR instead of the default string.

Modified tests/functional/adapter/grants/test_snapshot_grants.py to test the `dremio__type_string()` macro.
my_snapshot_sql previously overwrote `type_string()` with just "VARCHAR". Reverted back to use `type_string()` macro.

### Test Results

- [x] Component Tests
- [x] Functional Tests
- [x] Unit Tests

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

https://github.com/dremio/dbt-dremio/issues/78
