### PR TITLE
Update _populate_job_results pagination limit to be 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   Override dbt-core `default__type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
 
+-   Change \_populate_job_results() to have limit of 500 (Dremio's limit).
+
 ## Under the Hood
 
 ## Dependency

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -150,7 +150,7 @@ class DremioCursor:
     def _populate_job_results(self):
         if self._job_results == None:
             self._job_results = job_results(
-                self._parameters, self._job_id, offset=0, limit=100, ssl_verify=True
+                self._parameters, self._job_id, offset=0, limit=500, ssl_verify=True
             )
 
     def _populate_results_table(self):


### PR DESCRIPTION
### Summary

Update _populate_job_results pagination limit to be 500

### Description

Change __populate_job_results()'s call of job_results() to have a limit of 500, which is Dremio's limit. Part 1 of the fix, with part 2 being implementing pagination.

### Test Results

Ran all of the tests using software, with them all passing apart from a known failure in tests/functional/adapter/grants/test_model_grants.py.

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

https://github.com/dremio/dbt-dremio/issues/61