### PR TITLE
Implement job results pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 -   Override dbt-core `default__type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
 
--   Change \_populate_job_results() to have an optional row_limit argument with default set to 100 (Dremio's default).
+-   Change \_populate_job_results() to have an optional row_limit argument with default set to 100 (Dremio's default). ([#61](https://github.com/dremio/dbt-dremio/issues/61))
 
--   Implement pagination in \_populate_job_results()
+-   Implement pagination in \_populate_job_results() ([#61](https://github.com/dremio/dbt-dremio/issues/61))
 
 ## Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 -   Override dbt-core `default__type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
 
--   Change \_populate_job_results() to have limit of 500 (Dremio's limit).
+-   Change \_populate_job_results() to have page_limit of 100 (Dremio's default).
+
+-   Change \_populate_job_results() to have an additional optional page_limit argument.
 
 ## Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 -   Override dbt-core `default__type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
 
--   Change \_populate_job_results() to have page_limit of 100 (Dremio's default).
+-   Change \_populate_job_results() to have an optional page_limit argument with default set to 100 (Dremio's default).
 
--   Change \_populate_job_results() to have an additional optional page_limit argument.
+-   Implement pagination in \_populate_job_results()
 
 ## Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Override dbt-core `default__type_string()` macro to use Dremio Supported VARCHAR instead of the default string. ([#80](https://github.com/dremio/dbt-dremio/pull/80))
 
--   Change \_populate_job_results() to have an optional page_limit argument with default set to 100 (Dremio's default).
+-   Change \_populate_job_results() to have an optional row_limit argument with default set to 100 (Dremio's default).
 
 -   Implement pagination in \_populate_job_results()
 

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -149,17 +149,28 @@ class DremioCursor:
 
     def _populate_job_results(self):
         LIMIT = 1
-        if self._job_results == None and self._rowcount is not None:
-            current_row_count = 0
-            combined_job_results = None
+        if self._job_results == None:
+            combined_job_results = job_results(
+                self._parameters,
+                self._job_id,
+                offset=0,
+                limit=LIMIT,
+                ssl_verify=True,
+            )
+            total_row_count = combined_job_results["rowCount"]
+            current_row_count = len(combined_job_results["rows"])
 
-            while current_row_count < self._rowcount:
-                combined_job_results += job_results(
-                    self._parameters,
-                    self._job_id,
-                    offset=current_row_count,
-                    limit=LIMIT,
-                    ssl_verify=True,
+            while current_row_count < total_row_count:
+                # Limit to number of schema values?
+
+                combined_job_results["rows"].extend(
+                    job_results(
+                        self._parameters,
+                        self._job_id,
+                        offset=current_row_count,
+                        limit=LIMIT,
+                        ssl_verify=True,
+                    )["rows"]
                 )
                 current_row_count += LIMIT
 

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -147,13 +147,13 @@ class DremioCursor:
 
         self._rowcount = rows
 
-    def _populate_job_results(self, page_limit=100):
+    def _populate_job_results(self, row_limit=100):
         if self._job_results == None:
             combined_job_results = job_results(
                 self._parameters,
                 self._job_id,
                 offset=0,
-                limit=page_limit,
+                limit=row_limit,
                 ssl_verify=True,
             )
             total_row_count = combined_job_results["rowCount"]
@@ -165,11 +165,11 @@ class DremioCursor:
                         self._parameters,
                         self._job_id,
                         offset=current_row_count,
-                        limit=page_limit,
+                        limit=row_limit,
                         ssl_verify=True,
                     )["rows"]
                 )
-                current_row_count += page_limit
+                current_row_count += row_limit
 
             self._job_results = combined_job_results
 

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -148,10 +148,22 @@ class DremioCursor:
         self._rowcount = rows
 
     def _populate_job_results(self):
-        if self._job_results == None:
-            self._job_results = job_results(
-                self._parameters, self._job_id, offset=0, limit=500, ssl_verify=True
-            )
+        LIMIT = 1
+        if self._job_results == None and self._rowcount is not None:
+            current_row_count = 0
+            combined_job_results = None
+
+            while current_row_count < self._rowcount:
+                combined_job_results += job_results(
+                    self._parameters,
+                    self._job_id,
+                    offset=current_row_count,
+                    limit=LIMIT,
+                    ssl_verify=True,
+                )
+                current_row_count += LIMIT
+
+            self._job_results = combined_job_results
 
     def _populate_results_table(self):
         if self._job_results != None:

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -147,32 +147,29 @@ class DremioCursor:
 
         self._rowcount = rows
 
-    def _populate_job_results(self):
-        LIMIT = 1
+    def _populate_job_results(self, page_limit=100):
         if self._job_results == None:
             combined_job_results = job_results(
                 self._parameters,
                 self._job_id,
                 offset=0,
-                limit=LIMIT,
+                limit=page_limit,
                 ssl_verify=True,
             )
             total_row_count = combined_job_results["rowCount"]
             current_row_count = len(combined_job_results["rows"])
 
             while current_row_count < total_row_count:
-                # Limit to number of schema values?
-
                 combined_job_results["rows"].extend(
                     job_results(
                         self._parameters,
                         self._job_id,
                         offset=current_row_count,
-                        limit=LIMIT,
+                        limit=page_limit,
                         ssl_verify=True,
                     )["rows"]
                 )
-                current_row_count += LIMIT
+                current_row_count += page_limit
 
             self._job_results = combined_job_results
 

--- a/tests/unit/test_job_results.py
+++ b/tests/unit/test_job_results.py
@@ -63,15 +63,15 @@ class TestJobResults:
     @patch("dbt.adapters.dremio.api.cursor.job_results")
     def test_job_result_pagination(self, mocked_job_results_func):
         # Arrange
-        PAGE_LIMIT = 2
+        ROW_LIMIT = 2
         JOB_RESULT_TOTAL_CALLS = ceil(
-            self.mocked_job_results_dict[0]["rowCount"] / PAGE_LIMIT
+            self.mocked_job_results_dict[0]["rowCount"] / ROW_LIMIT
         )
         dremio_cursor_obj = DremioCursor(Parameters("hello", DremioAuthentication()))
         mocked_job_results_func.side_effect = self.mocked_job_results_dict
 
         # Act
-        dremio_cursor_obj._populate_job_results(page_limit=PAGE_LIMIT)
+        dremio_cursor_obj._populate_job_results(row_limit=ROW_LIMIT)
 
         # Assert
         assert dremio_cursor_obj._job_results == self.expected_combined_job_results

--- a/tests/unit/test_job_results.py
+++ b/tests/unit/test_job_results.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2022 Dremio Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from math import ceil
+from unittest.mock import patch
+from dbt.adapters.dremio.api.cursor import DremioCursor
+from dbt.adapters.dremio.api.parameters import Parameters
+from dbt.adapters.dremio.api.authentication import DremioAuthentication
+
+
+class TestJobResults:
+    mocked_job_results_dict = [
+        {
+            "rowCount": 7,
+            "schema": [{"name": "id", "type": {"name": "BIGINT"}}],
+            "rows": [{"id": 1}, {"id": 2}],
+        },
+        {
+            "rowCount": 7,
+            "schema": [{"name": "id", "type": {"name": "BIGINT"}}],
+            "rows": [{"id": 3}, {"id": 4}],
+        },
+        {
+            "rowCount": 7,
+            "schema": [{"name": "id", "type": {"name": "BIGINT"}}],
+            "rows": [{"id": 5}, {"id": 6}],
+        },
+        {
+            "rowCount": 7,
+            "schema": [{"name": "id", "type": {"name": "BIGINT"}}],
+            "rows": [{"id": 7}],
+        },
+        {  # Something is wrong if it reaches here
+            "rowCount": 0,
+            "schema": [{"name": "id", "type": {"name": "BIGINT"}}],
+            "rows": [{"id": 42}],
+        },
+    ]
+
+    expected_combined_job_results = {
+        "rowCount": 7,
+        "schema": [{"name": "id", "type": {"name": "BIGINT"}}],
+        "rows": [
+            {"id": 1},
+            {"id": 2},
+            {"id": 3},
+            {"id": 4},
+            {"id": 5},
+            {"id": 6},
+            {"id": 7},
+        ],
+    }
+
+    @patch("dbt.adapters.dremio.api.cursor.job_results")
+    def test_job_result_pagination(self, mocked_job_results_func):
+        # Arrange
+        PAGE_LIMIT = 2
+        JOB_RESULT_TOTAL_CALLS = ceil(
+            self.mocked_job_results_dict[0]["rowCount"] / PAGE_LIMIT
+        )
+        dremio_cursor_obj = DremioCursor(Parameters("hello", DremioAuthentication()))
+        mocked_job_results_func.side_effect = self.mocked_job_results_dict
+
+        # Act
+        dremio_cursor_obj._populate_job_results(page_limit=PAGE_LIMIT)
+
+        # Assert
+        assert dremio_cursor_obj._job_results == self.expected_combined_job_results
+        assert mocked_job_results_func.call_count == JOB_RESULT_TOTAL_CALLS


### PR DESCRIPTION
### Summary

Implement job results pagination

### Description

- Add optional row_limit argument to _populate_job_results().
- Set row_limit default to 100.
- Create test_job_result.py unit test that tests pagination.

### Test Results
#### smoke_test
softwareUP --> PASS
softwarePAT --> PASS

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

Resolves #61 
