### PR TITLE
Get the actual error message from Dremio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 -   Change \_populate_job_results() to have limit of 500 (Dremio's limit).
 
+-   Fix error handling so the error reported when a job fails is the actual error from Dremio. ([#69](https://github.com/dremio/dbt-dremio/issues/69))
+
 ## Under the Hood
 
 ## Dependency

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -126,11 +126,12 @@ class DremioCursor:
         while True:
             if job_status_state != last_job_state:
                 logger.debug(f"Job State = {job_status_state}")
-            if (
-                job_status_state == "COMPLETED"
-                or job_status_state == "CANCELLED"
-                or job_status_state == "FAILED"
-            ):
+
+            if job_status_state == "FAILED":
+                error_message = job_status_response["errorMessage"]
+                raise Exception(f"ERROR: {error_message}")
+
+            if job_status_state == "COMPLETED" or job_status_state == "CANCELLED":
                 break
             last_job_state = job_status_state
             job_status_response = job_status(self._parameters, job_id, ssl_verify=True)

--- a/tests/functional/adapter/grants/test_invalid_grants.py
+++ b/tests/functional/adapter/grants/test_invalid_grants.py
@@ -18,11 +18,10 @@ from tests.functional.adapter.grants.base_grants import BaseGrantsDremio
 from tests.utils.util import relation_from_name
 from dbt.tests.util import get_connection
 
-# Currently we return an HTTP error, but need to improve error handling
-# to get a better error message (https://github.com/dremio/dbt-dremio/issues/69)
+
 class TestInvalidGrantsDremio(BaseGrantsDremio, BaseInvalidGrants):
     def grantee_does_not_exist_error(self):
-        return "Can not fetch details for a job that is in [FAILED] state"
+        return "StatusRuntimeException: INTERNAL"
 
     def privilege_does_not_exist_error(self):
-        return "Can not fetch details for a job that is in [FAILED] state"
+        return "Failure parsing the query."

--- a/tests/unit/test_job_results.py
+++ b/tests/unit/test_job_results.py
@@ -67,7 +67,7 @@ class TestJobResults:
         JOB_RESULT_TOTAL_CALLS = ceil(
             self.mocked_job_results_dict[0]["rowCount"] / ROW_LIMIT
         )
-        dremio_cursor_obj = DremioCursor(Parameters("hello", DremioAuthentication()))
+        dremio_cursor_obj = DremioCursor(Parameters("base_url", DremioAuthentication()))
         mocked_job_results_func.side_effect = self.mocked_job_results_dict
 
         # Act

--- a/tests/unit/test_payload_error.py
+++ b/tests/unit/test_payload_error.py
@@ -7,7 +7,9 @@ from dbt.adapters.dremio.api.authentication import DremioAuthentication
 class TestPayloadErrorMessage(TestCase):
     @mock.patch("dbt.adapters.dremio.api.cursor.job_status")
     def test_payload_error(self, mocked_job_status):
-        dremio_cursor_object = DremioCursor(Parameters("hola", DremioAuthentication))
+        dremio_cursor_object = DremioCursor(
+            Parameters("base_url", DremioAuthentication)
+        )
         mocked_job_status.return_value = {
             "jobState": "FAILED",
             "errorMessage": "ERROR: Expected error message",

--- a/tests/unit/test_payload_error.py
+++ b/tests/unit/test_payload_error.py
@@ -1,0 +1,16 @@
+from unittest import mock, TestCase
+from dbt.adapters.dremio.api.cursor import DremioCursor
+from dbt.adapters.dremio.api.parameters import Parameters
+from dbt.adapters.dremio.api.authentication import DremioAuthentication
+
+
+class TestPayloadErrorMessage(TestCase):
+    @mock.patch("dbt.adapters.dremio.api.cursor.job_status")
+    def test_payload_error(self, mocked_job_status):
+        dremio_cursor_object = DremioCursor(Parameters("hola", DremioAuthentication))
+        mocked_job_status.return_value = {
+            "jobState": "FAILED",
+            "errorMessage": "ERROR: Expected error message",
+        }
+        with self.assertRaises(Exception, msg="ERROR: Expected error message"):
+            dremio_cursor_object._populate_rowcount()


### PR DESCRIPTION
### Summary

Prior to this change, we were not checking to see of a job is in a FAILED state. Instead, we would attempt to get job_results for every job, which would return an error about not being able to get results of a job in a failed state. Now we check to see if the job failed and return the error message in the payload.

### Description

In cursor.py:

```
            if job_status_state == "FAILED":
                error_message = job_status_response["errorMessage"]
                raise Exception(f"ERROR: {error_message}")
```

### Test Results

#### Unit Tests
tests/unit/test_connection.py .                                                               [ 50%]
tests/unit/test_payload_error.py .                                                            [100%]

================================= 2 passed in 1.08s ===================================

#### Grants Functional Tests
tests/functional/adapter/grants/test_incremental_grants.py .             [ 16%]
tests/functional/adapter/grants/test_invalid_grants.py .                 [ 33%]
tests/functional/adapter/grants/test_model_grants.py ..                  [ 66%]
tests/functional/adapter/grants/test_seed_grants.py .                    [ 83%]
tests/functional/adapter/grants/test_snapshot_grants.py .                [100%]

================== 6 passed, 18 warnings in 586.39s (0:09:46) ==================

#### Basic Functional Tests
tests/functional/adapter/basic/test_adapter_methods.py .                 [  7%]
tests/functional/adapter/basic/test_base_mat.py .                        [ 14%]
tests/functional/adapter/basic/test_docs_generate.py ...                 [ 35%]
tests/functional/adapter/basic/test_empty.py .                           [ 42%]
tests/functional/adapter/basic/test_ephemeral.py .                       [ 50%]
tests/functional/adapter/basic/test_generic_tests.py .                   [ 57%]
tests/functional/adapter/basic/test_incremental.py ..                    [ 71%]
tests/functional/adapter/basic/test_singular_ephemeral.py .              [ 78%]
tests/functional/adapter/basic/test_singular_tests.py .                  [ 85%]
tests/functional/adapter/basic/test_snapshots.py s.                      [100%]

================== 13 passed, 1 skipped, 35 warnings in 607.06s (0:10:07) ==================


### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

https://github.com/dremio/dbt-dremio/issues/69
