### PR TITLE
Implement base current timestamps test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   [#64](https://github.com/dremio/dbt-dremio/issues/64) Add BaseArrayTests and throw exceptions for unsupported Array Macros.
 -   [#117](https://github.com/dremio/dbt-dremio/issues/117) Add support for Query Comment Tests and Python 3.11
+-   [#117](https://github.com/dremio/dbt-dremio/issues/117) Add Base Current Timestamps Tests 
 
 ## Dependency
 

--- a/dbt/adapters/dremio/connections.py
+++ b/dbt/adapters/dremio/connections.py
@@ -60,13 +60,13 @@ class DremioConnectionManager(SQLConnectionManager):
         except Exception as e:
             logger.debug(f"Error running SQL: {sql}")
             self.release()
-            if isinstance(e, dbt.exceptions.RuntimeException):
+            if isinstance(e, dbt.exceptions.DbtRuntimeError):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
 
-            raise dbt.exceptions.RuntimeException(e)
+            raise dbt.exceptions.DbtRuntimeError(e)
 
     @classmethod
     def open(cls, connection):

--- a/tests/functional/adapter/utils/test_timestamps.py
+++ b/tests/functional/adapter/utils/test_timestamps.py
@@ -1,0 +1,19 @@
+import pytest
+from dbt.tests.adapter.utils.test_timestamps import BaseCurrentTimestamps
+from tests.fixtures.profiles import unique_schema, dbt_profile_data
+
+
+class TestCurrentTimestampDremio(BaseCurrentTimestamps):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "get_current_timestamp.sql": 'select {{ current_timestamp() }} as "current_timestamp"'
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_schema(self):
+        return {"current_timestamp": "timestamp"}
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return '''select (SELECT CURRENT_TIMESTAMP()) as "current_timestamp"'''


### PR DESCRIPTION
### Summary

Implement base current timestamps test

### Description

Overwrote the test to work with Dremio syntax. Dremio only has one timestamp type, so we implemented this test similar to many other adapters. 

### Test Results

Only ran the TestCurrentTimestampDremio test that was implemeneted in test_timestamps.py. No other functionality was altered, so no other tests were ran. 

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

https://github.com/dremio/dbt-dremio/issues/117 
