### PR TITLE
134 performance enhancement for information schematables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   [#64](https://github.com/dremio/dbt-dremio/issues/64) Add BaseArrayTests and throw exceptions for unsupported Array Macros.
 -   [#117](https://github.com/dremio/dbt-dremio/issues/117) Add support for Query Comment Tests and Python 3.11
+-   [#134]https://github.com/dremio/dbt-dremio/issues/134) Add dremio:exact_search_enabled variable that if set to true, replaces usage of ilike with a basic equality in dremio\_\_list_relations_without_caching when reflections are not enabled.
 
 ## Dependency
 

--- a/dbt/include/dremio/dbt_project.yml
+++ b/dbt/include/dremio/dbt_project.yml
@@ -17,11 +17,12 @@ version: 1.0
 config-version: 2
 
 quoting:
-  database: true
-  schema: true
-  identifier: true
+    database: true
+    schema: true
+    identifier: true
 
 macro-paths: ["macros"]
 
 vars:
-  'dremio:reflections_enabled': false
+    "dremio:reflections_enabled": false
+    "dremio:exact_search_enabled": false

--- a/dbt/include/dremio/macros/adapters/metadata.sql
+++ b/dbt/include/dremio/macros/adapters/metadata.sql
@@ -189,7 +189,11 @@ limitations under the License.*/
           end) as table_schema
           ,lower(table_type) as table_type
       from information_schema."tables"
-      where ilike(table_schema, '{{ schema_name }}')
+      {%- if var('dremio:exact_search_enabled', default=false) %}
+        where table_schema = '{{ schema_name }}'
+      {%- else %}
+        where ilike(table_schema, '{{ schema_name }}')
+      {%- endif %}
       and table_type <> 'system_table'
 
   {% endcall %}


### PR DESCRIPTION
### Summary

Performance Enhancement for information schematables

### Description

- Create a new variable `dremio:exact_search_enabled` which defaults to false
- If variable set to true, changes the ilike to a basic equality for the `dremio__list_relations_without_caching` macro when reflections are disabled (which is the default)

### Test Results

Thanks @ravjotbrar for running the test suite with the variable not set (which is the default).
All tests pass.

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md