### PR TITLE
Remove test case for verify_ssl that was missed in previous PR

### DIFF
--- a/tests/component/test_profile_template.py
+++ b/tests/component/test_profile_template.py
@@ -60,7 +60,6 @@ class TestProfileTemplate:
         "dremio_space": "@user",
         "dremio_space_folder": "no_schema",
         "threads": 1,
-        "verify_ssl": True,
     }
     _DREMIO_CLOUD_PROFILE_SPECIFIC_OPTIONS_WITH_DEFAULTS = {
         "cloud_host": "api.dremio.cloud",


### PR DESCRIPTION
### Summary

Remove test case for `verify_ssl` option.

### Description

The `verify_ssl` option was removed from the interactive profile creation, but the test wasn't updated to check for it.

### Test Results

Ran `test_profile_template.py`. Test now passes.

### Changelog

Not really necessary.

### Related Issue

None.
