### PR TITLE
Fix schema parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 -   [#199](https://github.com/dremio/dbt-dremio/issues/199) Populate PyPI's `long_description` with contents of `README.md`
 -   [#167](https://github.com/dremio/dbt-dremio/issues/167) Remove parentheses surrounding views in the create_view_as macro. In more complex queries, the parentheses cause performance issues. 
+-   [#176](https://github.com/dremio/dbt-dremio/issues/176) Make fetching model data optional by allowing users to set fetch value to true or false. This improves performance where job results do not need to be populated.
+-   [#203](https://github.com/dremio/dbt-dremio/issues/203) Allow for dots in schema name, by surrounding in single and double quotes.
 
 
 # dbt-dremio 1.5.0 - release June 22, 2023

--- a/tests/functional/adapter/dremio_specific/test_schema_parsing.py
+++ b/tests/functional/adapter/dremio_specific/test_schema_parsing.py
@@ -1,0 +1,40 @@
+import pytest
+import yaml
+from dbt.tests.util import (
+    run_dbt,
+    read_file,
+    write_file,
+)
+
+test_schema_parsing = """
+{{
+  config(
+    materialized = "table"
+  )
+}}
+select * from Samples."samples.dremio.com"."NYC-taxi-trips-iceberg" limit 10
+"""
+
+
+class TestSchemaParsingDremio:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_schema_parsing.sql": test_schema_parsing,
+        }
+
+    def update_config_file(self, updates, *paths):
+        current_yaml = read_file(*paths)
+        config = yaml.safe_load(current_yaml)
+        config["test"]["outputs"]["default"].update(updates)
+        new_yaml = yaml.safe_dump(config)
+        write_file(new_yaml, *paths)
+
+    def test_schema_with_dots(self, project):
+        self.update_config_file(
+            {"object_storage_path": 'dbtdremios3."test.dot"'},
+            project.profiles_dir,
+            "profiles.yml",
+        )
+
+        run_dbt(["run"])


### PR DESCRIPTION
### Summary

Prior to this change, users would not be able to specify a schema with a dot in it. For instance, schema.parse would get quoted as "schema"."parse", even though the user intended to quote the entire identifier. Now users can choose to wrap the schema in single quotes and add double quotes around the parts they want. 

### Description

Add regex to match a pattern containing quotes. Solution provided by @dremio-brock. 

### Test Results

All tests pass.

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

https://github.com/dremio/dbt-dremio/issues/203
