### PR TITLE
Add version v to macro ref

### DIFF
--- a/dbt/include/dremio/macros/builtins/builtins.sql
+++ b/dbt/include/dremio/macros/builtins/builtins.sql
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.*/
 
-{%- macro ref(model_name) -%}
-  {%- set relation = builtins.ref(model_name) -%}
+{%- macro ref(model_name, v=None) -%}
+  {%- set relation = builtins.ref(model_name, v=v) -%}
   {%- if execute -%}
     {%- set model = graph.nodes.values() | selectattr("name", "equalto", model_name) | list | first -%}
     {%- if model.config.materialized == 'reflection' -%}


### PR DESCRIPTION
### Summary

Add optional named parameter to macro ref.

### Description

To use model versions with dbt (https://docs.getdbt.com/docs/collaborate/govern/model-versions#how-is-this-different-from-just-creating-a-new-model) it is necessary to have a optional parameter v in the ref macro.

### Test Results

I tested it locally on our dremio installation

### Changelog

-   [ ] Added optional parameter v to the ref macro

### Related Issue

<!--- Link to issue where this is tracked -->
