### PR TITLE
Ensure adapter does not fetch actual records from materialization

### DIFF
--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -77,7 +77,7 @@ class DremioCursor:
         self._initialize()
         self.closed = True
 
-    def execute(self, sql, bindings=None, fetch=True):
+    def execute(self, sql, bindings=None, fetch=False):
         if self.closed:
             raise Exception("CursorClosed")
         if bindings is None:
@@ -147,7 +147,7 @@ class DremioCursor:
 
         self._rowcount = rows
 
-    def _populate_job_results(self, row_limit=100):
+    def _populate_job_results(self, row_limit=500):
         if self._job_results == None:
             combined_job_results = job_results(
                 self._parameters,
@@ -157,6 +157,11 @@ class DremioCursor:
             )
             total_row_count = combined_job_results["rowCount"]
             current_row_count = len(combined_job_results["rows"])
+
+            if total_row_count > 100000:
+                logger.warning(
+                    "Fetching more than 100000 records. This may result in slower performance."
+                )
 
             while current_row_count < total_row_count:
                 combined_job_results["rows"].extend(

--- a/dbt/adapters/dremio/connections.py
+++ b/dbt/adapters/dremio/connections.py
@@ -130,7 +130,7 @@ class DremioConnectionManager(SQLConnectionManager):
 
     # Auto_begin may not be relevant with the rest_api
     def add_query(
-        self, sql, auto_begin=True, bindings=None, abridge_sql_log=False, fetch=True
+        self, sql, auto_begin=True, bindings=None, abridge_sql_log=False, fetch=False
     ):
         connection = self.get_thread_connection()
         if auto_begin and connection.transaction_open is False:
@@ -176,7 +176,6 @@ class DremioConnectionManager(SQLConnectionManager):
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin, fetch=fetch)
         response = self.get_response(cursor)
-        # fetch = True
         if fetch:
             table = cursor.table
         else:

--- a/dbt/include/dremio/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/dremio/macros/materializations/incremental/incremental.sql
@@ -51,7 +51,9 @@ limitations under the License.*/
     {% set build_sql = get_create_table_as_sql(False, intermediate_relation, external_query(sql)) %}
     {% set need_swap = true %}
   {% else %}
-    {% do run_query(get_create_table_as_sql(True, temp_relation, external_query(sql))) %}
+    {% call statement('temp') -%}
+       {{ create_table_as(True, temp_relation, external_query(sql)) }}
+    {%- endcall %}
     {% do to_drop.append(temp_relation) %}
     {% do adapter.expand_target_column_types(
              from_relation=temp_relation,

--- a/dbt/include/dremio/macros/materializations/reflection/reflection.sql
+++ b/dbt/include/dremio/macros/materializations/reflection/reflection.sql
@@ -27,7 +27,7 @@ limitations under the License.*/
 
   {% if model.refs | length + model.sources | length == 1 %}
     {% if model.refs | length == 1 %}
-      {% set anchor = ref(model.refs[0][0]) %}
+      {% set anchor = ref(model.refs[0]['name']) %}
     {% else %}
       {% set anchor = source(model.sources[0][0], model.sources[0][1]) %}
     {% endif %}


### PR DESCRIPTION
### Summary

During the second run of an incremental materialization, the adapter would try and fetch records from the temporary table it is creating. This made the adapter hang if the table was large enough. 

### Description
Made the fetch configuration false by default. Also changed the run_query macro to use call_statement, as run_query will always fetch the data that is returned by the sql query. Thanks to @mxmarg for the initial iteration of this fix. 

### Related Issue

https://github.com/dremio/dbt-dremio/issues/211
