### PR TITLE
Add iceberg as table type in format

### DIFF
--- a/dbt/include/dremio/macros/adapters/format.sql
+++ b/dbt/include/dremio/macros/adapters/format.sql
@@ -54,7 +54,7 @@ for 'excel' :
     ,'pretty_print':'prettyPrint'} -%}
   {%- set options = [] -%}
   {%- set format = config.get('format', validator=validation.any[basestring]) or 'iceberg' -%}
-  {%- if format in ['text', 'json', 'arrow', 'parquet'] -%}
+  {%- if format in ['text', 'json', 'arrow', 'parquet', 'iceberg'] -%}
     {%- do options.append("type=>'" ~ format ~ "'") -%}
     {%- if format == 'text' -%}
       {%- for key in ['field_delimiter', 'line_delimiter', 'quote', 'comment', 'escape'] -%}

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from setuptools import find_namespace_packages, setup
 
 
-
 # pull the long description from the README
 README = Path(__file__).parent / "README.md"
 
@@ -22,7 +21,7 @@ README = Path(__file__).parent / "README.md"
 README
 
 package_name = "dbt-dremio"
-package_version = "1.5.0"
+package_version = "1.5.9"
 description = """The Dremio adapter plugin for dbt"""
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ README = Path(__file__).parent / "README.md"
 README
 
 package_name = "dbt-dremio"
-package_version = "1.5.9"
+package_version = "1.5.1"
 description = """The Dremio adapter plugin for dbt"""
 
 setup(


### PR DESCRIPTION
See https://github.com/dremio/dbt-dremio/issues/208 for a summary of the issue.

The fix involved adding iceberg as a format option when creating tables. Additionally, I changed the version to prepare for a minor release including these fixes. 
