### PR TITLE
Make schema parsing backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # dbt-dremio vNext - release TBD
 
-## Under the Hood
+## Changes
 
 -   [#199](https://github.com/dremio/dbt-dremio/issues/199) Populate PyPI's `long_description` with contents of `README.md`
 -   [#167](https://github.com/dremio/dbt-dremio/issues/167) Remove parentheses surrounding views in the create_view_as macro. In more complex queries, the parentheses cause performance issues. 
--   [#176](https://github.com/dremio/dbt-dremio/issues/176) Make fetching model data optional by allowing users to set fetch value to true or false. This improves performance where job results do not need to be populated.
+-   [#211](https://github.com/dremio/dbt-dremio/issues/211) Make fetching model data false by default. This improves performance where job results do not need to be populated.
 -   [#203](https://github.com/dremio/dbt-dremio/issues/203) Allow for dots in schema name, by surrounding in single and double quotes.
+-   [#193](https://github.com/dremio/dbt-dremio/issues/193) Fixes Reflection bug: The name argument to ref() must be a string, got <class 'jinja2.runtime.Undefined'>
 
 
 # dbt-dremio 1.5.0 - release June 22, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# dbt-dremio vNext - release TBD
+# dbt-dremio v1.5.1
 
 ## Changes
 
@@ -7,7 +7,7 @@
 -   [#211](https://github.com/dremio/dbt-dremio/issues/211) Make fetching model data false by default. This improves performance where job results do not need to be populated.
 -   [#203](https://github.com/dremio/dbt-dremio/issues/203) Allow for dots in schema name, by surrounding in single and double quotes.
 -   [#193](https://github.com/dremio/dbt-dremio/issues/193) Fixes Reflection bug: The name argument to ref() must be a string, got <class 'jinja2.runtime.Undefined'>
-
+-   [Versioning](https://github.com/dremio/dbt-dremio/pull/210) Added optional parameter v to the ref macro
 
 # dbt-dremio 1.5.0 - release June 22, 2023
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Version 1.5.1 of the dbt-dremio adapter is compatible with dbt-core versions 1.2
 ## Getting started
 
 -   [Install dbt-dremio](https://docs.getdbt.com/reference/warehouse-setups/dremio-setup)
-    -   Version 1.5.1 of dbt-dremio requires dbt-core >= 1.2.0 and <= 1.5.0. Installing dbt-dremio will automatically upgrade existing dbt-core versions earlier than 1.2.0 to 1.5.*, or install dbt-core v1.5.0 if no version of dbt-core is found.
+    -   Version 1.5.1 of dbt-dremio requires dbt-core >= 1.2.0 and <= 1.5.*. Installing dbt-dremio will automatically upgrade existing dbt-core versions earlier than 1.2.0 to 1.5.*, or install dbt-core v1.5.0 if no version of dbt-core is found.
 -   Read the [introduction](https://docs.getdbt.com/docs/introduction/) and [viewpoint](https://docs.getdbt.com/docs/about/viewpoint/)
 
 ## Join the dbt Community

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@
 
 dbt is the T in ELT. Organize, cleanse, denormalize, filter, rename, and pre-aggregate the raw data in your warehouse so that it's ready for analysis.
 
-## dbt-dremio version 1.5.0
+## dbt-dremio version 1.5.1
 
 The `dbt-dremio` package contains all of the code enabling dbt to work with [Dremio](https://www.dremio.com/). For more information on using dbt with Dremio, consult [the docs](https://docs.getdbt.com/reference/warehouse-profiles/dremio-profile).
 
 The dbt-dremio package supports both Dremio Cloud and Dremio Software (versions 22.0 and later).
 
-Version 1.5.0 of the dbt-dremio adapter is compatible with dbt-core versions 1.2.0 to 1.5.0.
+Version 1.5.1 of the dbt-dremio adapter is compatible with dbt-core versions 1.2.0 to 1.5.*.
 
 > Prior to version 1.1.0b, dbt-dremio was created and maintained by [Fabrice Etanchaud](https://github.com/fabrice-etanchaud) on [their GitHub repo](https://github.com/fabrice-etanchaud/dbt-dremio). Code for using Dremio REST APIs was originally authored by [Ryan Murray](https://github.com/rymurr). Contributors in this repo are credited for laying the groundwork and maintaining the adapter till version 1.0.6.5. The dbt-dremio adapter is maintained and distributed by Dremio starting with version 1.1.0b.
 
 ## Getting started
 
 -   [Install dbt-dremio](https://docs.getdbt.com/reference/warehouse-setups/dremio-setup)
-    -   Version 1.5.0 of dbt-dremio requires dbt-core >= 1.2.0 and <= 1.5.0. Installing dbt-dremio will automatically upgrade existing dbt-core versions earlier than 1.2.0 to 1.5.0, or install dbt-core v1.5.0 if no version of dbt-core is found.
+    -   Version 1.5.1 of dbt-dremio requires dbt-core >= 1.2.0 and <= 1.5.0. Installing dbt-dremio will automatically upgrade existing dbt-core versions earlier than 1.2.0 to 1.5.*, or install dbt-core v1.5.0 if no version of dbt-core is found.
 -   Read the [introduction](https://docs.getdbt.com/docs/introduction/) and [viewpoint](https://docs.getdbt.com/docs/about/viewpoint/)
 
 ## Join the dbt Community

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -14,7 +14,7 @@
  click                     8.1.3      BSD License
  colorama                  0.4.6      BSD License
  dbt-core                  1.5.0      Apache Software License
- dbt-dremio                1.5.0      Apache Software License
+ dbt-dremio                1.5.1      Apache Software License
  dbt-extractor             0.4.1      Apache Software License
  dbt-tests-adapter         1.5.0      Apache Software License
  exceptiongroup            1.1.1      MIT License

--- a/dbt/adapters/dremio/__version__.py
+++ b/dbt/adapters/dremio/__version__.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.5.0"
+version = "1.5.1"

--- a/dbt/adapters/dremio/relation.py
+++ b/dbt/adapters/dremio/relation.py
@@ -47,9 +47,15 @@ class DremioRelation(BaseRelation):
     format_clause: Optional[str] = None
 
     def quoted_by_component(self, identifier, componentName):
+        dot_char = "."
         if componentName == ComponentName.Schema:
-            PATTERN = re.compile(r"""((?:[^."']|"[^"]*"|'[^']*')+)""")
-            return ".".join(PATTERN.split(identifier)[1::2])
+            if '"' in identifier:
+                quote_pattern = re.compile(r"""((?:[^."']|"[^"]*"|'[^']*')+)""")
+                return dot_char.join(quote_pattern.split(identifier)[1::2])
+            else:
+                return dot_char.join(
+                    self.quoted(folder) for folder in identifier.split(dot_char)
+                )
 
         return self.quoted(identifier)
 


### PR DESCRIPTION
### Summary

We made changes to the schema parsing that allowed for schemas that contained dots. However, this requires users to specify ALL schemas wrapped in single quotes and then double quotes (`'"my_schema"'`), otherwise it won't add any quotes to schemas. With this change users can continue to add their schema as normal (`'my_schema'`).

### Description

Added a condition to check if double quotes are contained in the schema definition. If so, we use the most recent logic. If not we use the regular logic. 

### Test Results

<!--- Details of the tests you've ran -->

### Changelog

-   [ ] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

<!--- Link to issue where this is tracked -->
