### PR TITLE
Optimize REST API workload by using Session and slowing down polling loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Changes
 
--   [195](https://github.com/dremio/dbt-dremio/issues/195) Ensure the adapter does not try and create folders in object storage source
+-   [#195](https://github.com/dremio/dbt-dremio/issues/195) Ensure the adapter does not try and create folders in object storage source
+-   [#220](https://github.com/dremio/dbt-dremio/pull/220) Optimize networking performance with Dremio server
 
 
 # dbt-dremio v1.5.1

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import time
+
 import agate
 
 from dbt.adapters.dremio.api.rest.endpoints import (
@@ -123,6 +125,8 @@ class DremioCursor:
         job_status_state = job_status_response["jobState"]
 
         while True:
+            time.sleep(0.2)
+            
             if job_status_state != last_job_state:
                 logger.debug(f"Job State = {job_status_state}")
 

--- a/dbt/adapters/dremio/api/rest/endpoints.py
+++ b/dbt/adapters/dremio/api/rest/endpoints.py
@@ -39,9 +39,10 @@ from dbt.events import AdapterLogger
 
 logger = AdapterLogger("dremio")
 
+session = requests.Session()
 
 def _get(url, request_headers, details="", ssl_verify=True):
-    response = requests.get(url, headers=request_headers, verify=ssl_verify)
+    response = session.get(url, headers=request_headers, verify=ssl_verify)
     return _check_error(response, details)
 
 
@@ -55,7 +56,7 @@ def _post(
 ):
     if isinstance(json, str):
         json = jsonlib.loads(json)
-    response = requests.post(
+    response = session.post(
         url,
         headers=request_headers,
         timeout=timeout,
@@ -66,7 +67,7 @@ def _post(
 
 
 def _delete(url, request_headers, details="", ssl_verify=True):
-    response = requests.delete(url, headers=request_headers, verify=ssl_verify)
+    response = session.delete(url, headers=request_headers, verify=ssl_verify)
     return _check_error(response, details)
 
 


### PR DESCRIPTION
### Summary

The cursor implementation was using `while True` loop to poll for result from REST API of Dremio. Without throttling, it will jam the server easily, especially when using a high number of thread count. Since most SQL jobs need a few second to run, looping too fast to get the result is unessesary.

Also, in REST client implementation, using `get`, `post`, `delete` directly from `requests` is inefficient because it will create new HTTP session with the server everytime the polling is called.

### Description

1. Use `request.Session` instead of vanila `requests` to utilize connection pooling, so optimize networking performance
2. Add `time.sleep` in `while True` loop to slow down the polling

### Changelog

- [x] Added a summary of what this PR accomplishes to CHANGELOG.md
