### PR TITLE
Removed quotes from config_col macro.

### DIFF
--- a/dbt/include/dremio/macros/materializations/helpers.sql
+++ b/dbt/include/dremio/macros/materializations/helpers.sql
@@ -20,7 +20,7 @@ limitations under the License.*/
     {%- endif -%}
     {{ label }} (
     {%- for item in cols -%}
-      {{ adapter.quote(item) }}
+      {{ item }}
       {%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}
     )


### PR DESCRIPTION
### Summary

Removed qoutes from config_col macro to be able to define partition transformations.

### Description

As described in #201, when using transformations in `partition_by` statements, dbt-dremio currently raises an error which can be fixed by removing the default quoting.

### Test Results

With the changes, I can now use transformation on partition_by columns. 
```sql
{{ config(
    materialized='reflection',
    reflection_type='raw',
    partition_by=['month("date_col")'],
) }}
-- depends on {{ ref('view_definition') }}
```

You however have to use manually quote columns with irregular chars. 

### Changelog

-   [ ] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

#201 