### PR TITLE
Remove secrets and use dummy values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       SLEEP_INTERVAL: 5 # Sleep duration in seconds between retries
       MINIO_HEALTH_URL: http://localhost:9000/minio/health/live
       DREMIO_HEALTH_URL: http://localhost:9047
-      MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
-      MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
-      DREMIO_SOFTWARE_USERNAME: ${{ secrets.DREMIO_SOFTWARE_USERNAME }}
-      DREMIO_SOFTWARE_PASSWORD: ${{ secrets.DREMIO_SOFTWARE_PASSWORD }}
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+      DREMIO_SOFTWARE_USERNAME: dremio
+      DREMIO_SOFTWARE_PASSWORD: dremio123
       DREMIO_SOFTWARE_HOST: localhost
       DREMIO_DATALAKE: dbt_test_source
       DREMIO_DATABASE: dbt_test


### PR DESCRIPTION
### Summary

Removed the need for secrets usage

### Description

Removed the usage of secrets since they are not passed to workflows that are triggered by a pull request from a fork

These are dummy values since we setup and deploy instances locally in the pipeline itself

### Test Results

N/A

### Changelog

- moved dummy values out of secrets in `.github/workflows/ci.yml`

### Related Issue

N/A
