### PR TITLE
Unnamed reflections now take the model name/alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt-dremio v1.8.2
+
+## Changes
+
+- When naming reflections, if a `name` config is not set, the `alias` config parameter will be used instead. If also undefined, it will refer to the model name instead of using `Unnamed Reflection`
+
 # dbt-dremio v1.8.1
 
 ## Changes

--- a/dbt/include/dremio/macros/materializations/reflection/reflection.sql
+++ b/dbt/include/dremio/macros/materializations/reflection/reflection.sql
@@ -14,7 +14,7 @@ limitations under the License.*/
 
 {% materialization reflection, adapter='dremio' %}
 
-  {% set reflection_name = config.get('name', validator=validation.any[basetring]) or 'Unnamed Reflection' %}
+  {% set reflection_name = config.get('name', validator=validation.any[basetring]) or config.get('alias', validator=validation.any[basetring]) or model.name %}
   {% set raw_reflection_type = config.get('reflection_type', validator=validation.any[basestring]) or 'raw' %}
   {% set raw_anchor = config.get('anchor', validator=validation.any[list, basestring]) %}
   {% set raw_external_target = config.get('external_target', validator=validation.any[list, basestring]) %}


### PR DESCRIPTION
### Summary

When creating a model for a reflection, if the name config parameter was not set, the reflection would be named `Unnamed Reflection` inside Dremio.

### Description

Instead, the default behavior should be for the reflection to be named after the model name/alias
The default behavior has been changed, it will now set the name attending to the following priority list:

1. Model config `name` parameter
2. Model config `alias` parameter
3. Model name

### Test Results

Two new tests have been added to the test suit for reflections, one with the `alias` parameter and another one with the model name

### Changelog

-   [X] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

#263 
