### PR TITLE
fix: Issue with on_schema_change config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 - When naming reflections, if a `name` config is not set, the `alias` config parameter will be used instead. If also undefined, it will refer to the model name instead of using `Unnamed Reflection`
 - Grants can now be set for both users and for roles. A prefix was added to handle this, with `user:` and `role:` being the valid prefixes. For example, `user:dbt_test_user_1` and `role:dbt_test_role_1`. If no prefix is provided, defaults to user for backwards compatibility.
+- Moves the `raw_on_schema_change` variable back into scope for the config validator
+- Adds `BaseIncrementalOnSchemaChange` test to test_incremental.py
 
 ## Features
 
 - [#259](https://github.com/dremio/dbt-dremio/pull/259) Added support for roles in grants
+- [#273](https://github.com/dremio/dbt-dremio/pull/273) Fix issue with on_schema_change config
 
 # dbt-dremio v1.8.1
 
@@ -32,7 +35,7 @@
   - Integration via REST API
 
 ## Features
- 
+
 -   [#250](https://github.com/dremio/dbt-dremio/pull/250) Implementation of wikis and tags feature
 -   [#250](https://github.com/dremio/dbt-dremio/pull/256) Reflections are now handled through the Rest API
 
@@ -60,7 +63,7 @@
 ## Changes
 
 -   [#199](https://github.com/dremio/dbt-dremio/issues/199) Populate PyPI's `long_description` with contents of `README.md`
--   [#167](https://github.com/dremio/dbt-dremio/issues/167) Remove parentheses surrounding views in the create_view_as macro. In more complex queries, the parentheses cause performance issues. 
+-   [#167](https://github.com/dremio/dbt-dremio/issues/167) Remove parentheses surrounding views in the create_view_as macro. In more complex queries, the parentheses cause performance issues.
 -   [#211](https://github.com/dremio/dbt-dremio/issues/211) Make fetching model data false by default. This improves performance where job results do not need to be populated.
 -   [#203](https://github.com/dremio/dbt-dremio/issues/203) Allow for dots in schema name, by surrounding in single and double quotes.
 -   [#193](https://github.com/dremio/dbt-dremio/issues/193) Fixes Reflection bug: The name argument to ref() must be a string, got <class 'jinja2.runtime.Undefined'>

--- a/dbt/include/dremio/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/dremio/macros/materializations/incremental/incremental.sql
@@ -25,6 +25,7 @@ limitations under the License.*/
   -- configs
   {%- set unique_key = config.get('unique_key', validator=validation.any[list, basestring]) -%}
   {%- set full_refresh_mode = (should_full_refresh()) -%}
+  {%- set raw_on_schema_change = config.get('on_schema_change', validator=validation.any[basestring]) or 'ignore' -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(raw_on_schema_change) -%}
 
   -- the temp_ and backup_ relations should not already exist in the database; get_relation
@@ -70,7 +71,6 @@ limitations under the License.*/
     {%- set file_format = dbt_dremio_validate_get_file_format(raw_file_format) -%}
     {%- set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) -%}
     {%- set strategy = dbt_dremio_validate_get_incremental_strategy(incremental_strategy) -%}
-    {%- set raw_on_schema_change = config.get('on_schema_change', validator=validation.any[basestring]) or 'ignore' -%}
     {% set build_sql = dbt_dremio_get_incremental_sql(strategy, intermediate_relation, target_relation, dest_columns, unique_key) %}
     
   {% endif %}

--- a/tests/functional/adapter/basic/test_incremental.py
+++ b/tests/functional/adapter/basic/test_incremental.py
@@ -20,6 +20,9 @@ from dbt.tests.adapter.basic.test_incremental import (
 from dbt.tests.adapter.incremental.test_incremental_merge_exclude_columns import (
     BaseMergeExcludeColumns,
 )
+from dbt.tests.adapter.incremental.test_incremental_on_schema_change import (
+    BaseIncrementalOnSchemaChange,
+)
 from tests.fixtures.profiles import unique_schema, dbt_profile_data
 from tests.utils.util import BUCKET, SOURCE
 from dbt.tests.util import run_dbt, relation_from_name, check_relations_equal
@@ -110,6 +113,9 @@ class TestIncrementalDremio(BaseIncremental):
 
 
 class TestBaseIncrementalNotSchemaChange(BaseIncrementalNotSchemaChange):
+    pass
+
+class TestIncrementalOnSchemaChange(BaseIncrementalOnSchemaChange):
     pass
 
 


### PR DESCRIPTION
### Summary

This fixes the on_schema_change config

### Description

- Moves the `raw_on_schema_change` variable back into scope for the config validator

### Test Results

Reproduced the bug described in #268, made changes to a local version of `dbt-dremio` and confirmed that it was behaving as expected.

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

resolves: #268
