### PR TITLE
fix: Add identifier and schema to `get_relation_last_modified` macro

### DIFF
--- a/dbt/include/dremio/macros/adapters/metadata.sql
+++ b/dbt/include/dremio/macros/adapters/metadata.sql
@@ -307,8 +307,10 @@ limitations under the License.*/
   {%- if relation.type != 'view' -%}
 
     {%- call statement('last_modified', fetch_result=True) -%}
-          select max(committed_at) as last_modified,
-                {{ current_timestamp() }} as snapshotted_at
+          select  '{{ relation.identifier}}' as identifier,
+                  '{{ relation.schema}}' as schema,
+                  max(committed_at) as last_modified,
+                  {{ current_timestamp() }} as snapshotted_at
           from TABLE( table_snapshot('{{relation}}') )
     {%- endcall -%}
   {%- else -%}


### PR DESCRIPTION
### Summary

The `get_relation_last_modified` macro currently returns an invalid data structure, causing compilation errors when running `dbt source freshness`.

This PR adds identifier and schema columns and keeps the existing data structure expected by dbt.

### Description

After updating `dbt` and `dbt-dremio` from 1.7 to 1.8, I noticed that freshness checks no longer work:

```bash
20:41:23    Compilation Error in source <SOURCE> (models/sources.yml)
  Got an invalid result from "get_relation_last_modified" macro: [(datetime.datetime(2025, 1, 31, 20, 13, 6), datetime.datetime(2025, 1, 31, 20, 41, 22))]
```


After reading https://github.com/dbt-labs/dbt-core/discussions/8307, especially looking at the `get_relation_last_modified` [reference implementation](https://github.com/dbt-labs/dbt-snowflake/blob/cf854b5c1c9b6b8e9b84e77c4f27b4ede3fc47df/dbt/include/snowflake/macros/metadata.sql) from Snowflake, I noticed we don't return 

- `schema` and
- `identifier`

With this change, `dbt source freshness` returns proper freshness information without compilation errors.


### Test Results


### Changelog

-   [ ] Added a summary of what this PR accomplishes to CHANGELOG.md

### Related Issue

