### PR TITLE
Fix Invalid Quoting Around Partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Grants can now be set for both users and for roles. A prefix was added to handle this, with `user:` and `role:` being the valid prefixes. For example, `user:dbt_test_user_1` and `role:dbt_test_role_1`. If no prefix is provided, defaults to user for backwards compatibility.
 - Moves the `raw_on_schema_change` variable back into scope for the config validator
 - Adds `BaseIncrementalOnSchemaChange` test to test_incremental.py
-
+- Changed logic for partitioning when materializing tables. Double quoting issue has been removed, now letting the user decide the quoting
+    - New example: `partition_by=['month("datetime_utc")']`
 ## Features
 
 - [#259](https://github.com/dremio/dbt-dremio/pull/259) Added support for roles in grants

--- a/dbt/include/dremio/macros/materializations/helpers.sql
+++ b/dbt/include/dremio/macros/materializations/helpers.sql
@@ -19,10 +19,7 @@ limitations under the License.*/
       {%- set cols = [cols] -%}
     {%- endif -%}
     {{ label }} (
-    {%- for item in cols -%}
-      {{ adapter.quote(item) }}
-      {%- if not loop.last -%},{%- endif -%}
-    {%- endfor -%}
+    {{ cols | join(', ') }}
     )
   {%- endif %}
 {%- endmacro -%}


### PR DESCRIPTION
### Summary

When using `partition_by`, dbt-dremio could be causing invalid statements to partition columns, surrounding the way quotation was being handled.

### Description

The sistematic double quoting has been removed from the connector's logic, stopping such situations from happening and leaving quotation to be decided by the user. An example of a table materialization under this new logic is:

```
{{
    config(
        materialized = 'table',
        partition_by = ['forecast_effective_date', 'year("datetime_utc")', 'month("datetime_hour_ending_utc")']
    )
}}
```

### Test Results

n/a

### Changelog

-   [X] Added a summary of what this PR accomplishes to CHANGELOG.md

### Contributor License Agreement

<!--- Applicable for non Dremio employees and for first time contributors -->

-   [X] Please make sure you have signed our [Contributor License Agreement](https://www.dremio.com/legal/contributor-agreement/), which enables Dremio to distribute your contribution without restriction.

### Related Issue

#201 
