### PR TITLE
Adding new check if the space already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt-dremio v1.8.3
+
+## Changes
+
+- Adds check for catalog/space existence during model creation. It would unblock using non admin users in DC to run dbt-dremio.
+
 # dbt-dremio v1.8.2
 
 ## Changes

--- a/dbt/adapters/dremio/connections.py
+++ b/dbt/adapters/dremio/connections.py
@@ -224,8 +224,8 @@ class DremioConnectionManager(SQLConnectionManager):
         database = relation.database
         schema = relation.schema
 
-        if database == ("@" + credentials.UID) or self.__catalog_exists(
-            [database]):
+        if database == ("@" + credentials.UID) or self._catalog_exists(
+            database):
             logger.debug(
                 "Database is default or already exists: creating folders only")
         else:
@@ -237,14 +237,14 @@ class DremioConnectionManager(SQLConnectionManager):
             self._create_folders(database, schema, rest_client)
         return
 
-    def __catalog_exists(self, path):
+    def _catalog_exists(self, path: str):
         thread_connection = self.get_thread_connection()
         connection = self.open(thread_connection)
         rest_client = connection.handle.get_client()
         try:
             catalog_info = rest_client.get_catalog_item(
                 catalog_id=None,
-                catalog_path=path,
+                catalog_path=[path],
             )
             return catalog_info.get("id") is not None
         except DremioNotFoundException:

--- a/dbt/adapters/dremio/connections.py
+++ b/dbt/adapters/dremio/connections.py
@@ -224,8 +224,10 @@ class DremioConnectionManager(SQLConnectionManager):
         database = relation.database
         schema = relation.schema
 
-        if database == ("@" + credentials.UID):
-            logger.debug("Database is default: creating folders only")
+        if database == ("@" + credentials.UID) or self.__catalog_exists(
+            [database]):
+            logger.debug(
+                "Database is default or already exists: creating folders only")
         else:
             logger.debug(f"Creating space: {database}")
             self._create_space(database, rest_client)
@@ -234,7 +236,20 @@ class DremioConnectionManager(SQLConnectionManager):
             logger.debug(f"Creating folder(s): {database}.{schema}")
             self._create_folders(database, schema, rest_client)
         return
-    
+
+    def __catalog_exists(self, path):
+        thread_connection = self.get_thread_connection()
+        connection = self.open(thread_connection)
+        rest_client = connection.handle.get_client()
+        try:
+            catalog_info = rest_client.get_catalog_item(
+                catalog_id=None,
+                catalog_path=path,
+            )
+            return catalog_info.get("id") is not None
+        except DremioNotFoundException:
+            return False
+
     # dbt docs integration with Dremio wikis and tags
     def process_wikis(self, relation, text: str):
         logger.debug("Integrating wikis")
@@ -244,7 +259,7 @@ class DremioConnectionManager(SQLConnectionManager):
         database = relation.database
         schema = relation.schema
 
-        path = self._create_path_list(database,schema)
+        path = self._create_path_list(database, schema)
         identifier = relation.identifier
         path.append(identifier)
         try:


### PR DESCRIPTION
### Summary

Adding check if catalog/space already exists. It will unblock non-admin users in DC from starting to use dbt-dremio. 

### Description

Before only ADMIN users of DC were able to run dbt-dremio. Now we are checking if the catalog exists and it unblocks customers to use non-admin users in DC with dbt-dremio.

### Test Results

Created a tech dept ticket to create dbt-dremio tests for it. Run only manual tests with DC instance.

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md

