### PR TITLE
Include dbt-dremio version in query metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes
 
+- Included dbt-dremio version in query metadata
 - Adjusted existing pipeline scripts to support Jenkins
 
 # dbt-dremio v1.8.3

--- a/dbt/adapters/dremio/connections.py
+++ b/dbt/adapters/dremio/connections.py
@@ -211,14 +211,14 @@ class DremioConnectionManager(SQLConnectionManager):
     @classmethod
     def data_type_code_to_name(cls, type_code) -> str:
         return type_code
-    
+
     def execute(
             self,
             sql: str,
             auto_begin: bool = False,
             fetch: bool = False,
             limit: Optional[int] = None,
-    ) -> Tuple[AdapterResponse, agate.Table]:        
+    ) -> Tuple[AdapterResponse, agate.Table]:
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin, fetch=fetch)
         response = self.get_response(cursor)


### PR DESCRIPTION
### Summary

We are trying to understand the adoption and distribution of dbt-dremio from DC usage data, therefore, we are including an additional value in query metadata that represents the version of dbt-dremio adapter.

Metadata before changes: `/* {"app": "dbt", "dbt_version": "1.8.8", "profile_name": <profile_name>, "target_name": <target_name>, ... } */`

Metadata after changes: `/* {"app": "dbt", "dbt_version": "1.8.8", "dbt_dremio_version": "1.8.3", "profile_name": <profile_name>, "target_name": <target_name>, ... } */`

### Description

- Created a new macro `DREMIO_QUERY_COMMENT`, which includes the dbt-dremio's version, to replace the default query comment `DEFAULT_QUERY_COMMENT` macro
- Created a new class `DremioMacroQueryStringSetter` that inherits `MacroQueryStringSetter` to override the method that configures the query comment macro to be evaluated

### Test Results

All tests are passing, no new tests added - query comment tests already exists and no updates are needed

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md
