### PR TITLE
dbt 1.9 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Dependency
 
-- Upgraded dbt-core to 1.9.1 and dbt-tests-adapter to 1.10.1
+- Upgraded dbt-core to 1.9.0 and dbt-tests-adapter to 1.11.0
 
 # dbt-dremio v1.8.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# dbt-dremio v1.9.0
+
+## Changes
+
+- Updated dbt-dremio to match dbt-core v1.9 with the snapshots improvements
+
+## Dependency
+
+- Upgraded dbt-core to 1.9.1 and dbt-tests-adapter to 1.10.1
+
 # dbt-dremio v1.8.4
 
 ## Changes

--- a/dbt/adapters/dremio/__version__.py
+++ b/dbt/adapters/dremio/__version__.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.8.4"
+version = "1.9.0"

--- a/dbt/include/dremio/macros/adapters/snapshot.sql
+++ b/dbt/include/dremio/macros/adapters/snapshot.sql
@@ -14,22 +14,34 @@ limitations under the License.*/
 
 
 {% macro dremio__snapshot_merge_sql(target, source, insert_cols) -%}
-    {%- set insert_cols_csv = insert_cols | join(', ') -%}
+  {%- set columns = config.get("snapshot_table_column_names") or get_snapshot_table_column_names() -%}
+  {%- set insert_cols_csv = insert_cols | join(', ') -%}
 
-    merge into {{ target }} as DBT_INTERNAL_DEST
-    using {{ source }} as DBT_INTERNAL_SOURCE
-    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id
+  merge into {{ target }} as DBT_INTERNAL_DEST
+  using {{ source }} as DBT_INTERNAL_SOURCE
+  on DBT_INTERNAL_SOURCE.{{ columns.dbt_scd_id }} = DBT_INTERNAL_DEST.{{ columns.dbt_scd_id }}
 
-    when matched
-        then update
-        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
+  when matched
+    {%- if config.get("dbt_valid_to_current") %}
+      and (
+        DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} = {{ config.get('dbt_valid_to_current') }}
+        or DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null
+      )
+    {%- else %}
+      and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null
+    {%- endif %}
+    and DBT_INTERNAL_SOURCE.dbt_change_type in ('update','delete')
+    then update
+      set {{ columns.dbt_valid_to }} = DBT_INTERNAL_SOURCE.{{ columns.dbt_valid_to }}
 
-    when not matched
-        then insert ({{ insert_cols_csv }})
-        values
-            ({% for column_name in insert_cols -%}
-                DBT_INTERNAL_SOURCE.{{ column_name }}
-                {%- if not loop.last %}, {%- endif %}
-            {%- endfor %})
+  when not matched
+    and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'
+    then insert ({{ insert_cols_csv }})
+    values
+    (
+      {%- for column_name in insert_cols -%}
+        DBT_INTERNAL_SOURCE.{{ column_name }}{% if not loop.last %}, {% endif %}
+      {%- endfor %}
+    )
 
 {% endmacro %}

--- a/dbt/include/dremio/macros/builtins/builtins.sql
+++ b/dbt/include/dremio/macros/builtins/builtins.sql
@@ -24,8 +24,8 @@ limitations under the License.*/
       and model.config.format is defined
       else none -%}
     {%- set format_clause = format_clause_from_node(model.config) if format is not none else none -%}
-    {%- set relation2 = api.Relation.create(database=relation.database, schema=relation.schema, identifier=relation.identifier, format=format, format_clause=format_clause) -%}
-    {{ return (relation2) }}
+    {%- set relation2 = api.Relation.create(database=relation.database, schema=relation.schema, identifier=relation.identifier, format=format, format_clause=format_clause, limit=relation.limit) -%}
+      {{ return (relation2) }}
   {%- else -%}
     {{ return (relation) }}
   {%- endif -%}
@@ -40,8 +40,8 @@ limitations under the License.*/
       and source.external.format is defined
       else none -%}
     {%- set format_clause = format_clause_from_node(source.external) if format is not none else none -%}
-    {%- set relation2 = api.Relation.create(database=relation.database, schema=relation.schema, identifier=relation.identifier, format=format, format_clause=format_clause) -%}
-    {{ return (relation2) }}
+    {%- set relation2 = api.Relation.create(database=relation.database, schema=relation.schema, identifier=relation.identifier, format=format, format_clause=format_clause, limit=relation.limit) -%}
+      {{ return (relation2) }}
   {%- else -%}
     {{ return (relation) }}
   {%- endif -%}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,8 +3,8 @@ Babel==2.12.1
 betterproto==1.2.5
 certifi==2023.7.22
 charset-normalizer==3.1.0
-dbt-core==1.8.8
-dbt-tests-adapter==1.8.0
+dbt-core==1.9.1
+dbt-tests-adapter==1.10.1
 python-dotenv==1.0.1
 exceptiongroup==1.1.1
 future==0.18.3

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,8 +3,8 @@ Babel==2.12.1
 betterproto==1.2.5
 certifi==2023.7.22
 charset-normalizer==3.1.0
-dbt-core==1.9.1
-dbt-tests-adapter==1.10.1
+dbt-core==1.9.0
+dbt-tests-adapter==1.11.0
 python-dotenv==1.0.1
 exceptiongroup==1.1.1
 future==0.18.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ README
 
 package_name = "dbt-dremio"
 
-package_version = "1.9.0"
+package_version = "1.8.4"
 
 description = """The Dremio adapter plugin for dbt"""
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ README
 
 package_name = "dbt-dremio"
 
-package_version = "1.8.4"
+package_version = "1.9.0"
 
 description = """The Dremio adapter plugin for dbt"""
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ README
 
 package_name = "dbt-dremio"
 
-package_version = "1.8.4"
+package_version = "1.9.0"
 
 description = """The Dremio adapter plugin for dbt"""
 
@@ -37,8 +37,9 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-core>=1.8",
-        "dbt-adapters>=1.0.0, <2.0.0",
+        "dbt-core>=1.9",
+        "dbt-common>=1.13.0,<2.0",
+        "dbt-adapters>=1.10.1, <2.0",
         "requests>=2.31.0",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core>=1.9",
-        "dbt-common>=1.13.0,<2.0",
+        "dbt-common>=1.11,<2.0",
         "dbt-adapters>=1.10.1, <2.0",
         "requests>=2.31.0",
     ],

--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -41,15 +41,3 @@ class TestDremioEmpty(BaseTestEmpty):
             "model.sql": _models.model_sql,
             "sources.yml": schema_sources_yml,
         }
-
-    def test_run_with_empty(self, project):
-        # create source from seed
-        run_dbt(["seed"])
-
-        # run without empty - 3 expected rows in output - 1 from each input
-        # run_dbt(["run"])
-        # self.assert_row_count(project, "model", 3)
-
-        # run with empty - 0 expected rows in output
-        run_dbt(["build", "--empty"])
-        self.assert_row_count(project, "model", 0)

--- a/tests/functional/adapter/materialization/fixtures.py
+++ b/tests/functional/adapter/materialization/fixtures.py
@@ -1,0 +1,261 @@
+create_seed_sql = """
+create table {database}.{schema}.seed (
+    id INTEGER,
+    first_name VARCHAR(50),
+    last_name VARCHAR(50),
+    email VARCHAR(50),
+    gender VARCHAR(50),
+    ip_address VARCHAR(20),
+    updated_at TIMESTAMP
+);
+"""
+
+create_snapshot_expected_sql = """
+create table {database}.{schema}.snapshot_expected (
+    id INTEGER,
+    first_name VARCHAR(50),
+    last_name VARCHAR(50),
+    email VARCHAR(50),
+    gender VARCHAR(50),
+    ip_address VARCHAR(20),
+
+    -- snapshotting fields
+    updated_at TIMESTAMP,
+    test_valid_from TIMESTAMP,
+    test_valid_to   TIMESTAMP,
+    test_scd_id     VARCHAR,
+    test_updated_at TIMESTAMP
+);
+"""
+
+
+seed_insert_sql = """
+-- seed inserts
+--  use the same email for two users to verify that duplicated check_cols values
+--  are handled appropriately
+insert into {database}.{schema}.seed (id, first_name, last_name, email, gender, ip_address, updated_at) values
+(1, 'Judith', 'Kennedy', '(not provided)', 'Female', '54.60.24.128', '2015-12-24 12:19:28'),
+(2, 'Arthur', 'Kelly', '(not provided)', 'Male', '62.56.24.215', '2015-10-28 16:22:15'),
+(3, 'Rachel', 'Moreno', 'rmoreno2@msu.edu', 'Female', '31.222.249.23', '2016-04-05 02:05:30'),
+(4, 'Ralph', 'Turner', 'rturner3@hp.com', 'Male', '157.83.76.114', '2016-08-08 00:06:51'),
+(5, 'Laura', 'Gonzales', 'lgonzales4@howstuffworks.com', 'Female', '30.54.105.168', '2016-09-01 08:25:38'),
+(6, 'Katherine', 'Lopez', 'klopez5@yahoo.co.jp', 'Female', '169.138.46.89', '2016-08-30 18:52:11'),
+(7, 'Jeremy', 'Hamilton', 'jhamilton6@mozilla.org', 'Male', '231.189.13.133', '2016-07-17 02:09:46'),
+(8, 'Heather', 'Rose', 'hrose7@goodreads.com', 'Female', '87.165.201.65', '2015-12-29 22:03:56'),
+(9, 'Gregory', 'Kelly', 'gkelly8@trellian.com', 'Male', '154.209.99.7', '2016-03-24 21:18:16'),
+(10, 'Rachel', 'Lopez', 'rlopez9@themeforest.net', 'Female', '237.165.82.71', '2016-08-20 15:44:49'),
+(11, 'Donna', 'Welch', 'dwelcha@shutterfly.com', 'Female', '103.33.110.138', '2016-02-27 01:41:48'),
+(12, 'Russell', 'Lawrence', 'rlawrenceb@qq.com', 'Male', '189.115.73.4', '2016-06-11 03:07:09'),
+(13, 'Michelle', 'Montgomery', 'mmontgomeryc@scientificamerican.com', 'Female', '243.220.95.82', '2016-06-18 16:27:19'),
+(14, 'Walter', 'Castillo', 'wcastillod@pagesperso-orange.fr', 'Male', '71.159.238.196', '2016-10-06 01:55:44'),
+(15, 'Robin', 'Mills', 'rmillse@vkontakte.ru', 'Female', '172.190.5.50', '2016-10-31 11:41:21'),
+(16, 'Raymond', 'Holmes', 'rholmesf@usgs.gov', 'Male', '148.153.166.95', '2016-10-03 08:16:38'),
+(17, 'Gary', 'Bishop', 'gbishopg@plala.or.jp', 'Male', '161.108.182.13', '2016-08-29 19:35:20'),
+(18, 'Anna', 'Riley', 'arileyh@nasa.gov', 'Female', '253.31.108.22', '2015-12-11 04:34:27'),
+(19, 'Sarah', 'Knight', 'sknighti@foxnews.com', 'Female', '222.220.3.177', '2016-09-26 00:49:06'),
+(20, 'Phyllis', 'Fox', null, 'Female', '163.191.232.95', '2016-08-21 10:35:19');
+"""
+
+
+populate_snapshot_expected_sql = """
+-- populate snapshot table
+insert into {database}.{schema}.snapshot_expected (
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    test_valid_from,
+    test_valid_to,
+    test_updated_at,
+    test_scd_id
+)
+
+select
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    -- fields added by snapshotting
+    updated_at as test_valid_from,
+    cast(null as timestamp) as test_valid_to,
+    updated_at as test_updated_at,
+    md5(id || '-' || first_name || '|' || cast(updated_at as varchar)) as test_scd_id
+from {database}.{schema}.seed;
+"""
+
+populate_snapshot_expected_valid_to_current_sql = """
+-- populate snapshot table
+insert into {database}.{schema}.snapshot_expected (
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    test_valid_from,
+    test_valid_to,
+    test_updated_at,
+    test_scd_id
+)
+
+select
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    -- fields added by snapshotting
+    updated_at as test_valid_from,
+    cast('2099-12-31' as timestamp) as test_valid_to,
+    updated_at as test_updated_at,
+    md5(id || '-' || first_name || '|' || cast(updated_at as varchar)) as test_scd_id
+from {database}.{schema}.seed;
+"""
+
+snapshot_actual_sql = """
+{% snapshot snapshot_actual %}
+
+    {{
+        config(
+            unique_key='id || ' ~ "'-'" ~ ' || first_name',
+        )
+    }}
+
+    select * from {{target.database}}.{{target.schema}}.seed
+
+{% endsnapshot %}
+"""
+
+snapshots_yml = """
+snapshots:
+  - name: snapshot_actual
+    config:
+      strategy: timestamp
+      updated_at: updated_at
+      snapshot_meta_column_names:
+          dbt_valid_to: test_valid_to
+          dbt_valid_from: test_valid_from
+          dbt_scd_id: test_scd_id
+          dbt_updated_at: test_updated_at
+"""
+
+snapshots_no_column_names_yml = """
+snapshots:
+  - name: snapshot_actual
+    config:
+      strategy: timestamp
+      updated_at: updated_at
+"""
+
+ref_snapshot_sql = """
+select * from {{ ref('snapshot_actual') }}
+"""
+
+
+invalidate_seed_sql = """
+-- update records 11 - 21. Change email and updated_at field
+update {database}.{schema}.seed set
+    updated_at = TIMESTAMPADD(SQL_TSI_HOUR, 1, updated_at),
+    email      =  case when id = 20 then 'pfoxj@creativecommons.org' else 'new_' || email end
+where id >= 10 and id <= 20
+"""
+
+invalidate_snapshot_sql = """
+-- invalidate records 11 - 21
+update {database}.{schema}.snapshot_expected set
+    test_valid_to   = TIMESTAMPADD(SQL_TSI_HOUR, 1, updated_at)
+where id >= 10 and id <= 20
+"""
+
+update_sql = """
+-- insert v2 of the 11 - 21 records
+
+insert into {database}.{schema}.snapshot_expected (
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    test_valid_from,
+    test_valid_to,
+    test_updated_at,
+    test_scd_id
+)
+
+select
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    -- fields added by snapshotting
+    updated_at as test_valid_from,
+    cast(null as timestamp) as test_valid_to,
+    updated_at as test_updated_at,
+    md5(id || '-' || first_name || '|' || cast(updated_at as varchar)) as test_scd_id
+from {database}.{schema}.seed
+where id >= 10 and id <= 20;
+"""
+
+# valid_to_current fixtures
+
+snapshots_valid_to_current_yml = """
+snapshots:
+  - name: snapshot_actual
+    config:
+      strategy: timestamp
+      updated_at: updated_at
+      dbt_valid_to_current: "cast('2099-12-31' as timestamp)"
+      snapshot_meta_column_names:
+          dbt_valid_to: test_valid_to
+          dbt_valid_from: test_valid_from
+          dbt_scd_id: test_scd_id
+          dbt_updated_at: test_updated_at
+"""
+
+update_with_current_sql = """
+-- insert v2 of the 11 - 21 records
+
+insert into {database}.{schema}.snapshot_expected (
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    test_valid_from,
+    test_valid_to,
+    test_updated_at,
+    test_scd_id
+)
+
+select
+    id,
+    first_name,
+    last_name,
+    email,
+    gender,
+    ip_address,
+    updated_at,
+    -- fields added by snapshotting
+    updated_at as test_valid_from,
+    cast('2099-12-31' as timestamp) as test_valid_to,
+    updated_at as test_updated_at,
+    md5(id || '-' || first_name || '|' || cast(updated_at as varchar)) as test_scd_id
+from {database}.{schema}.seed
+where id >= 10 and id <= 20;
+"""

--- a/tests/functional/adapter/materialization/test_snapshots.py
+++ b/tests/functional/adapter/materialization/test_snapshots.py
@@ -12,18 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import pytest
+from dbt.tests.util import (
+    check_relations_equal,
+    get_manifest,
+    run_dbt,
+    run_dbt_and_capture,
+    run_sql_with_adapter,
+    update_config_file,
+)
 from dbt.tests.adapter.basic.test_snapshot_check_cols import (
     BaseSnapshotCheckCols,
 )
 from dbt.tests.adapter.basic.test_snapshot_timestamp import (
     BaseSnapshotTimestamp,
 )
-from dbt.tests.adapter.simple_snapshot.test_various_configs import (
-    BaseSnapshotDbtValidToCurrent,
-    BaseSnapshotColumnNames,
-    BaseSnapshotColumnNamesFromDbtProject,
-    BaseSnapshotInvalidColumnNames,
+# TODO: Reuse some of the tests when path issue is fixed on dbt-tests-adapter
+# from dbt.tests.adapter.simple_snapshot.test_various_configs import (
+#     BaseSnapshotDbtValidToCurrent,
+#     BaseSnapshotColumnNames,
+#     BaseSnapshotColumnNamesFromDbtProject,
+#     BaseSnapshotInvalidColumnNames,
+# )
+from tests.functional.adapter.materialization.fixtures import (
+    create_seed_sql,
+    create_snapshot_expected_sql,
+    invalidate_seed_sql,
+    invalidate_snapshot_sql,
+    populate_snapshot_expected_sql,
+    populate_snapshot_expected_valid_to_current_sql,
+    ref_snapshot_sql,
+    seed_insert_sql,
+    snapshot_actual_sql,
+    snapshots_no_column_names_yml,
+    snapshots_valid_to_current_yml,
+    snapshots_yml,
+    update_sql,
+    update_with_current_sql,
 )
 from tests.utils.util import BUCKET
 
@@ -104,14 +130,316 @@ class TestSnapshotTimestampDremio(BaseSnapshotTimestamp):
             "name": "snapshot_strategy_timestamp",
         }
 
-class TestSnapshotDbtValidToCurrentDremio(BaseSnapshotDbtValidToCurrent):
-    pass
+class TestSnapshotDbtValidToCurrentDremio:
+    @pytest.fixture(scope="class")
+    def unique_schema(self, request, prefix) -> str:
+        test_file = request.module.__name__
+        # We only want the last part of the name
+        test_file = test_file.split(".")[-1]
+        unique_schema = f"{BUCKET}.{prefix}_{test_file}"
+        return unique_schema
 
-class TestSnapshotColumnNamesDremio(BaseSnapshotColumnNames):
-    pass
+    @pytest.fixture(scope="class")
+    def dbt_profile_data(
+        self, unique_schema, dbt_profile_target, profiles_config_update
+    ):
+        profile = {
+            "test": {
+                "outputs": {
+                    "default": {},
+                },
+                "target": "default",
+            },
+        }
+        target = dbt_profile_target
+        target["schema"] = unique_schema
+        target["root_path"] = unique_schema
+        target["database"] = target["datalake"]
+        profile["test"]["outputs"]["default"] = target
 
-class TestSnapshotColumnNamesFromDbtProjectDremio(BaseSnapshotColumnNamesFromDbtProject):
-    pass
+        if profiles_config_update:
+            profile.update(profiles_config_update)
+        return profile
 
-class TestSnapshotInvalidColumnNamesDremio(BaseSnapshotInvalidColumnNames):
-    pass
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"snapshot.sql": snapshot_actual_sql}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "snapshots.yml": snapshots_valid_to_current_yml,
+            "ref_snapshot.sql": ref_snapshot_sql,
+        }
+    
+    def test_valid_to_current(self, project):
+        project.run_sql(create_seed_sql)
+        project.run_sql(create_snapshot_expected_sql)
+        project.run_sql(seed_insert_sql)
+        project.run_sql(populate_snapshot_expected_valid_to_current_sql)
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        original_snapshot = run_sql_with_adapter(
+            project.adapter,
+            "select id, test_scd_id, test_valid_to from {database}.{schema}.snapshot_actual",
+            "all",
+        )
+
+        assert original_snapshot[0][2] == datetime.datetime(2099, 12, 31, 0, 0)
+        assert original_snapshot[9][2] == datetime.datetime(2099, 12, 31, 0, 0)
+
+        # Split the two statement sql invalidate_sql
+        project.run_sql(invalidate_seed_sql)
+        project.run_sql(invalidate_snapshot_sql)
+        project.run_sql(update_with_current_sql)
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        # The order of the rows seems to vary by each run, so we need to sort them
+        updated_snapshot = run_sql_with_adapter(
+            project.adapter,
+            "select id, test_scd_id, test_valid_to from {database}.{schema}.snapshot_actual order by id, updated_at asc",
+            "all",
+        )
+
+        assert updated_snapshot[0][2] == datetime.datetime(2099, 12, 31, 0, 0)
+        # Original row that was updated now has a non-current (2099/12/31) date
+        assert updated_snapshot[9][2] == datetime.datetime(2016, 8, 20, 16, 44, 49)
+        # Updated row has a current date
+        assert updated_snapshot[20][2] == datetime.datetime(2099, 12, 31, 0, 0)
+
+        check_relations_equal(project.adapter, ["snapshot_actual", "snapshot_expected"])
+
+class TestSnapshotColumnNamesDremio:
+    @pytest.fixture(scope="class")
+    def unique_schema(self, request, prefix) -> str:
+        test_file = request.module.__name__
+        # We only want the last part of the name
+        test_file = test_file.split(".")[-1]
+        unique_schema = f"{BUCKET}.{prefix}_{test_file}"
+        return unique_schema
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_data(
+        self, unique_schema, dbt_profile_target, profiles_config_update
+    ):
+        profile = {
+            "test": {
+                "outputs": {
+                    "default": {},
+                },
+                "target": "default",
+            },
+        }
+        target = dbt_profile_target
+        target["schema"] = unique_schema
+        target["root_path"] = unique_schema
+        target["database"] = target["datalake"]
+        profile["test"]["outputs"]["default"] = target
+
+        if profiles_config_update:
+            profile.update(profiles_config_update)
+        return profile
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"snapshot.sql": snapshot_actual_sql}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "snapshots.yml": snapshots_yml,
+            "ref_snapshot.sql": ref_snapshot_sql,
+        }
+
+    def test_snapshot_column_names(self, project):
+        project.run_sql(create_seed_sql)
+        project.run_sql(create_snapshot_expected_sql)
+        project.run_sql(seed_insert_sql)
+        project.run_sql(populate_snapshot_expected_sql)
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        project.run_sql(invalidate_seed_sql)
+        project.run_sql(invalidate_snapshot_sql)
+        project.run_sql(update_sql)
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        check_relations_equal(project.adapter, ["snapshot_actual", "snapshot_expected"])
+
+class TestSnapshotColumnNamesFromDbtProjectDremio:
+    @pytest.fixture(scope="class")
+    def unique_schema(self, request, prefix) -> str:
+        test_file = request.module.__name__
+        # We only want the last part of the name
+        test_file = test_file.split(".")[-1]
+        unique_schema = f"{BUCKET}.{prefix}_{test_file}"
+        return unique_schema
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_data(
+        self, unique_schema, dbt_profile_target, profiles_config_update
+    ):
+        profile = {
+            "test": {
+                "outputs": {
+                    "default": {},
+                },
+                "target": "default",
+            },
+        }
+        target = dbt_profile_target
+        target["schema"] = unique_schema
+        target["root_path"] = unique_schema
+        target["database"] = target["datalake"]
+        profile["test"]["outputs"]["default"] = target
+
+        if profiles_config_update:
+            profile.update(profiles_config_update)
+        return profile
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"snapshot.sql": snapshot_actual_sql}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "snapshots.yml": snapshots_no_column_names_yml,
+            "ref_snapshot.sql": ref_snapshot_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "snapshots": {
+                "test": {
+                    "+snapshot_meta_column_names": {
+                        "dbt_valid_to": "test_valid_to",
+                        "dbt_valid_from": "test_valid_from",
+                        "dbt_scd_id": "test_scd_id",
+                        "dbt_updated_at": "test_updated_at",
+                    }
+                }
+            }
+        }
+
+    def test_snapshot_column_names_from_project(self, project):
+        project.run_sql(create_seed_sql)
+        project.run_sql(create_snapshot_expected_sql)
+        project.run_sql(seed_insert_sql)
+        project.run_sql(populate_snapshot_expected_sql)
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        project.run_sql(invalidate_seed_sql)
+        project.run_sql(invalidate_snapshot_sql)
+        project.run_sql(update_sql)
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        check_relations_equal(project.adapter, ["snapshot_actual", "snapshot_expected"])
+
+class TestSnapshotInvalidColumnNamesDremio:
+    @pytest.fixture(scope="class")
+    def unique_schema(self, request, prefix) -> str:
+        test_file = request.module.__name__
+        # We only want the last part of the name
+        test_file = test_file.split(".")[-1]
+        unique_schema = f"{BUCKET}.{prefix}_{test_file}"
+        return unique_schema
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_data(
+        self, unique_schema, dbt_profile_target, profiles_config_update
+    ):
+        profile = {
+            "test": {
+                "outputs": {
+                    "default": {},
+                },
+                "target": "default",
+            },
+        }
+        target = dbt_profile_target
+        target["schema"] = unique_schema
+        target["root_path"] = unique_schema
+        target["database"] = target["datalake"]
+        profile["test"]["outputs"]["default"] = target
+
+        if profiles_config_update:
+            profile.update(profiles_config_update)
+        return profile
+        
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"snapshot.sql": snapshot_actual_sql}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "snapshots.yml": snapshots_no_column_names_yml,
+            "ref_snapshot.sql": ref_snapshot_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "snapshots": {
+                "test": {
+                    "+snapshot_meta_column_names": {
+                        "dbt_valid_to": "test_valid_to",
+                        "dbt_valid_from": "test_valid_from",
+                        "dbt_scd_id": "test_scd_id",
+                        "dbt_updated_at": "test_updated_at",
+                    }
+                }
+            }
+        }
+
+    def test_snapshot_invalid_column_names(self, project):
+        project.run_sql(create_seed_sql)
+        project.run_sql(create_snapshot_expected_sql)
+        project.run_sql(seed_insert_sql)
+        project.run_sql(populate_snapshot_expected_sql)
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+        manifest = get_manifest(project.project_root)
+        snapshot_node = manifest.nodes["snapshot.test.snapshot_actual"]
+        snapshot_node.config.snapshot_meta_column_names == {
+            "dbt_valid_to": "test_valid_to",
+            "dbt_valid_from": "test_valid_from",
+            "dbt_scd_id": "test_scd_id",
+            "dbt_updated_at": "test_updated_at",
+        }
+
+        project.run_sql(invalidate_seed_sql)
+        project.run_sql(invalidate_snapshot_sql)
+        project.run_sql(update_sql)
+
+        # Change snapshot_meta_columns and look for an error
+        different_columns = {
+            "snapshots": {
+                "test": {
+                    "+snapshot_meta_column_names": {
+                        "dbt_valid_to": "test_valid_to",
+                        "dbt_updated_at": "test_updated_at",
+                    }
+                }
+            }
+        }
+        update_config_file(different_columns, "dbt_project.yml")
+
+        results, log_output = run_dbt_and_capture(["snapshot"], expect_pass=False)
+        assert len(results) == 1
+        assert "Compilation Error in snapshot snapshot_actual" in log_output
+        assert "Snapshot target is missing configured columns" in log_output

--- a/tests/functional/adapter/materialization/test_snapshots.py
+++ b/tests/functional/adapter/materialization/test_snapshots.py
@@ -19,6 +19,12 @@ from dbt.tests.adapter.basic.test_snapshot_check_cols import (
 from dbt.tests.adapter.basic.test_snapshot_timestamp import (
     BaseSnapshotTimestamp,
 )
+from dbt.tests.adapter.simple_snapshot.test_various_configs import (
+    BaseSnapshotDbtValidToCurrent,
+    BaseSnapshotColumnNames,
+    BaseSnapshotColumnNamesFromDbtProject,
+    BaseSnapshotInvalidColumnNames,
+)
 from tests.utils.util import BUCKET
 
 
@@ -97,3 +103,15 @@ class TestSnapshotTimestampDremio(BaseSnapshotTimestamp):
             "seeds": {"+twin_strategy": "prevent"},
             "name": "snapshot_strategy_timestamp",
         }
+
+class TestSnapshotDbtValidToCurrentDremio(BaseSnapshotDbtValidToCurrent):
+    pass
+
+class TestSnapshotColumnNamesDremio(BaseSnapshotColumnNames):
+    pass
+
+class TestSnapshotColumnNamesFromDbtProjectDremio(BaseSnapshotColumnNamesFromDbtProject):
+    pass
+
+class TestSnapshotInvalidColumnNamesDremio(BaseSnapshotInvalidColumnNames):
+    pass

--- a/tests/functional/adapter/materialization/test_snapshots.py
+++ b/tests/functional/adapter/materialization/test_snapshots.py
@@ -22,14 +22,6 @@ from dbt.tests.adapter.basic.test_snapshot_timestamp import (
 from tests.utils.util import BUCKET
 
 
-from dbt.tests.adapter.basic import files
-from dbt.tests.util import relation_from_name, run_dbt, update_rows
-
-def check_relation_rows(project, snapshot_name, count):
-    relation = relation_from_name(project.adapter, snapshot_name)
-    result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
-    assert result[0] == count
-
 class TestSnapshotCheckColsDremio(BaseSnapshotCheckCols):
     @pytest.fixture(scope="class")
     def unique_schema(self, request, prefix) -> str:
@@ -67,78 +59,6 @@ class TestSnapshotCheckColsDremio(BaseSnapshotCheckCols):
             "seeds": {"+twin_strategy": "prevent"},
             "name": "snapshot_strategy_check_cols",
         }
-
-    def test_snapshot_check_cols(self, project):
-        # seed command
-        results = run_dbt(["seed", "--debug"])
-        assert len(results) == 2
-
-        # snapshot command
-        results = run_dbt(["snapshot", "--debug"])
-        for result in results:
-            assert result.status == "success"
-
-        # check rowcounts for all snapshots
-        check_relation_rows(project, "cc_all_snapshot", 10)
-        check_relation_rows(project, "cc_name_snapshot", 10)
-        check_relation_rows(project, "cc_date_snapshot", 10)
-
-        relation = relation_from_name(project.adapter, "cc_all_snapshot")
-        result = project.run_sql(f"select * from {relation}", fetch="all")
-
-        # point at the "added" seed so the snapshot sees 10 new rows
-        results = run_dbt(["--no-partial-parse", "snapshot", "--vars", "seed_name: added", "--debug"])
-        for result in results:
-            assert result.status == "success"
-
-        # check rowcounts for all snapshots
-        check_relation_rows(project, "cc_all_snapshot", 20)
-        check_relation_rows(project, "cc_name_snapshot", 20)
-        check_relation_rows(project, "cc_date_snapshot", 20)
-
-        # update some timestamps in the "added" seed so the snapshot sees 10 more new rows
-        update_rows_config = {
-            "name": "added",
-            "dst_col": "some_date",
-            "clause": {"src_col": "some_date", "type": "add_timestamp"},
-            "where": "id > 10 and id < 21",
-        }
-        update_rows(project.adapter, update_rows_config)
-
-        # re-run snapshots, using "added'
-        results = run_dbt(["snapshot", "--vars", "seed_name: added", "--debug"])
-        for result in results:
-            assert result.status == "success"
-
-        # check rowcounts for all snapshots
-        check_relation_rows(project, "cc_all_snapshot", 30)
-        check_relation_rows(project, "cc_date_snapshot", 30)
-        # unchanged: only the timestamp changed
-        check_relation_rows(project, "cc_name_snapshot", 20)
-
-        # Update the name column
-        update_rows_config = {
-            "name": "added",
-            "dst_col": "name",
-            "clause": {
-                "src_col": "name",
-                "type": "add_string",
-                "value": "_updated",
-            },
-            "where": "id < 11",
-        }
-        update_rows(project.adapter, update_rows_config)
-
-        # re-run snapshots, using "added'
-        results = run_dbt(["snapshot", "--vars", "seed_name: added", "--debug"])
-        for result in results:
-            assert result.status == "success"
-
-        # check rowcounts for all snapshots
-        check_relation_rows(project, "cc_all_snapshot", 40)
-        check_relation_rows(project, "cc_name_snapshot", 30)
-        # does not see name updates
-        check_relation_rows(project, "cc_date_snapshot", 30)
 
 class TestSnapshotTimestampDremio(BaseSnapshotTimestamp):
     @pytest.fixture(scope="class")

--- a/tests/hooks/test_run_hooks.py
+++ b/tests/hooks/test_run_hooks.py
@@ -13,14 +13,13 @@ import os
 import pytest
 
 from pathlib import Path
+from dbt_common.exceptions.base import DbtRuntimeError
 
 from tests.hooks.fixtures import (
     macros__hook,
     macros__before_and_after,
     models__hooks,
-    seeds__example_seed_csv,
-    macros_missing_column,
-    models__missing_column,
+    seeds__example_seed_csv
 )
 
 from dbt.tests.util import (
@@ -28,7 +27,7 @@ from dbt.tests.util import (
     run_dbt,
 )
 
-from dbt.tests.adapter.hooks.test_run_hooks import TestAfterRunHooks
+from dbt.tests.adapter.hooks.test_run_hooks import BaseAfterRunHooks
 
 from tests.utils.util import BUCKET, SOURCE
 
@@ -195,11 +194,9 @@ class TestPrePostRunHooksDremio(object):
         self.assert_used_schemas(project)
 
 
-class TestAfterRunHooksDremio(TestAfterRunHooks):
-    @pytest.fixture(scope="class")
-    def macros(self):
-        return {"temp_macro.sql": macros_missing_column}
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {"test_column.sql": models__missing_column}
+class TestAfterRunHooksDremio(BaseAfterRunHooks):
+    def test_missing_column_pre_hook(self, project):
+        # Changing DbtDatabaseError to DbtRuntimeError because our exception_handler
+        # only raises DbtRuntimeError
+        with pytest.raises(DbtRuntimeError):
+            run_dbt(["run"], expect_pass=False)


### PR DESCRIPTION
### Summary

Updating dbt-dremio to match dbt-core v1.9.0.

### Description

Following [Adapter Maintainers: Upgrading to dbt-core v1.9.0](https://github.com/dbt-labs/dbt-core/discussions/11125):
- Snapshot improvements
   - Snapshots: Enable setting a datetime value for `dbt_valid_to` for current records instead of `NULL`
   - Snapshots: Enable `hard_deletes` config to add a metadata column if a record has been deleted (automatically inherited from dbt-adapters)
   - Snapshots: Allow customizing names of metadata fields
   - Snapshots: Enable `unique_key` as a list (automatically inherited from dbt-adapters)
- Microbatch incremental strategy → optional, so not included in this PR

### Test Results

- Fixed _tests/hooks/test_run_hooks.py_
- Added `TestSnapshotDbtValidToCurrentDremio`, `TestSnapshotColumnNamesDremio`, `TestSnapshotColumnNamesFromDbtProjectDremio` and `TestSnapshotInvalidColumnNamesDremio` tests for the snapshot improvements

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md
