### PR TITLE
Support Dremio Enterprise Catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changes
 
 - Updated dbt-dremio to match dbt-core v1.9 with the snapshots improvements
+- Support for Dremio Enterprise Catalogs
 
 ## Dependency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Updated dbt-dremio to match dbt-core v1.9 with the snapshots improvements
 - Support for Dremio Enterprise Catalogs
 
+## Features
+
+- [#298](https://github.com/dremio/dbt-dremio/pull/298) Support for Dremio Enterprise Catalogs
+
 ## Dependency
 
 - Upgraded dbt-core to 1.9.0 and dbt-tests-adapter to 1.11.0

--- a/dbt/adapters/dremio/credentials.py
+++ b/dbt/adapters/dremio/credentials.py
@@ -91,7 +91,18 @@ class DremioCredentials(Credentials):
         )
 
     @classmethod
-    def __pre_deserialize__(cls, data):
+    def __pre_deserialize__(cls, data): # data is the project profile configuration
+        enterprise_catalog_configs = ["enterprise_catalog_namespace", "enterprise_catalog_folder"]
+        using_enterprise_catalog = all(key in data for key in enterprise_catalog_configs)
+        # Using enterprise catalog means using it to store both tables and views
+        # So internally we set it as both source and space before aliasing
+        if using_enterprise_catalog:
+            data["object_storage_source"] = data["enterprise_catalog_namespace"]
+            data["object_storage_path"] = data["enterprise_catalog_folder"]
+            data["dremio_space"] = data["enterprise_catalog_namespace"]
+            data["dremio_space_folder"] = data["enterprise_catalog_folder"]
+            del data["enterprise_catalog_namespace"]
+            del data["enterprise_catalog_folder"]
         data = super().__pre_deserialize__(data)
         if "cloud_host" not in data:
             data["cloud_host"] = None

--- a/dbt/adapters/dremio/credentials.py
+++ b/dbt/adapters/dremio/credentials.py
@@ -16,6 +16,7 @@ from dbt.adapters.contracts.connection import Credentials
 from dataclasses import dataclass
 from typing import Optional
 from dbt.adapters.dremio.relation import DremioRelation
+from dbt_common.exceptions import DbtValidationError
 
 
 @dataclass
@@ -91,9 +92,16 @@ class DremioCredentials(Credentials):
         )
 
     @classmethod
-    def __pre_deserialize__(cls, data): # data is the project profile configuration
+    def __pre_deserialize__(cls, data):
+        # data parameter is the project profile configuration already aliased
+        space_source_configs = ["datalake", "root_path", "database", "schema"]
+        using_space_source = all(key in data for key in space_source_configs)
         enterprise_catalog_configs = ["enterprise_catalog_namespace", "enterprise_catalog_folder"]
         using_enterprise_catalog = all(key in data for key in enterprise_catalog_configs)
+        if using_space_source and using_enterprise_catalog:
+            raise DbtValidationError(
+                "Cannot use both enterprise catalog and individual storage configurations"
+            )
         # Using enterprise catalog means using it to store both tables and views
         # So internally we set it as both source and space before aliasing
         if using_enterprise_catalog:

--- a/dbt/include/dremio/macros/materializations/clone.sql
+++ b/dbt/include/dremio/macros/materializations/clone.sql
@@ -15,44 +15,5 @@ limitations under the License.*/
 {%- materialization clone, adapter= 'dremio' -%}
 
   {{ exceptions.raise_not_implemented('Clone command not supported in dbt-dremio. You may clone tables as views using twin_strategy.') }}
-  {%- set relations = {'relations': []} -%}
-
-  {%- if not defer_relation -%}
-      -- nothing to do
-      {{ log("No relation found in state manifest for " ~ model.unique_id, info=True) }}
-      {{ return(relations) }}
-  {%- endif -%}
-
-  {%- set existing_relation = load_cached_relation(this) -%}
-
-  {%- if existing_relation and not flags.FULL_REFRESH -%}
-      -- noop!
-      {{ log("Relation " ~ existing_relation ~ " already exists", info=True) }}
-      {{ return(relations) }}
-  {%- endif -%}
-
-  -- Dremio does not support zero copy cloning of tables, so this will be cloned as a view
-  {%- set target_relation = api.Relation.create(
-          identifier=generate_alias_name_impl(model.name, config.get('file', validator=validation.any[basestring]), model),
-          schema=generate_schema_name_impl(target.root_path, config.get('root_path', validator=validation.any[basestring]), model),
-          database=generate_database_name_impl(target.datalake, config.get('datalake', validator=validation.any[basestring]), model),
-          type='table') -%}
-
-  {{exceptions.warn("Cloning tables is not supported. Applying twin strategy instead.")}}
-  {%- set view_relation = api.Relation.create(
-          identifier=generate_alias_name_impl(model.name, config.get('alias', validator=validation.any[basestring]), model),
-          schema=generate_schema_name_impl(target.schema, config.get('schema', validator=validation.any[basestring]), model),
-          database=generate_database_name_impl(target.database, config.get('database', validator=validation.any[basestring]), model),
-          type='view') -%}
-
-  {%- set sql_view -%}
-          select *
-          from {{ render_with_format_clause(target_relation) }}
-  {%- endset -%}
-
-  {% call statement('clone_view') -%}
-    {{ create_view_as(view_relation, sql_view) }}
-  {%- endcall %}
-
 
 {%- endmaterialization -%}

--- a/dbt/include/dremio/macros/materializations/twin_strategy.sql
+++ b/dbt/include/dremio/macros/materializations/twin_strategy.sql
@@ -13,41 +13,54 @@ See the License for the specific language governing permissions and
 limitations under the License.*/
 
 {%- macro apply_twin_strategy(target_relation) -%}
-  {%- set twin_strategy = config.get('twin_strategy', validator=validation.any[basestring]) or 'clone' -%}
-  
-  {%- set view_relation = api.Relation.create(
-    identifier=generate_alias_name_impl(model.name, config.get('alias', validator=validation.any[basestring]), model),
-    schema=generate_schema_name_impl(target.schema, config.get('schema', validator=validation.any[basestring]), model),
-    database=generate_database_name_impl(target.database, config.get('database', validator=validation.any[basestring]), model),
-    type='view') -%}
+  {%- set object_storage_source = target.datalake -%}
+  {%- set object_storage_path = target.root_path -%}
+  {%- set dremio_space = target.database -%}
+  {%- set dremio_space_folder = target.schema -%}
 
-  {%- set conflicting_relation = none -%}
-  {%- if target_relation.type == 'view' -%}
-    {%- set table_relation = api.Relation.create(
-        identifier=generate_alias_name_impl(model.name, config.get('file', validator=validation.any[basestring]), model),
-        schema=generate_schema_name_impl(target.root_path, config.get('root_path', validator=validation.any[basestring]), model),
-        database=generate_database_name_impl(target.datalake, config.get('datalake', validator=validation.any[basestring]), model),
-        type='table') -%}
-    {%- set conflicting_relation = adapter.get_relation(database=table_relation.database, schema=table_relation.schema, identifier=table_relation.identifier) -%}
-  {%- elif target_relation.type == 'table' -%}
-    {%- set conflicting_relation = adapter.get_relation(database=view_relation.database, schema=view_relation.schema, identifier=view_relation.identifier) -%}
-  {%- endif -%}
+  {%- set using_enterprise_catalog = (object_storage_source == dremio_space and object_storage_path == dremio_space_folder) -%}
 
-  {%- if conflicting_relation is not none and target_relation.type != conflicting_relation.type -%}
-    {%- if twin_strategy == 'prevent' -%}
-      -- Prevent strategy -> Drop the conflicting relation
-      {{ adapter.drop_relation(conflicting_relation) }}
-    {%- elif twin_strategy == 'clone' -%}
-      -- Clone strategy -> Create a view selecting from the correct relation
-      {%- set sql_view -%}
-        select *
-        from {{ render_with_format_clause(
-          target_relation.type == 'view' and conflicting_relation or target_relation
-        ) }}
-      {%- endset -%}
-      {% call statement('clone_relation') -%}
-        {{ create_view_as(view_relation, sql_view) }}
-      {%- endcall %} 
+  {%- if using_enterprise_catalog -%}
+    {%- if config.get('twin_strategy') is not none -%}
+      {% do exceptions.warn("WARNING: Twin strategy not applied - using enterprise catalog") %}
     {%- endif -%}
+  {%- else -%}
+    {%- set twin_strategy = config.get('twin_strategy', validator=validation.any[basestring]) or 'clone' -%}
+    
+    {%- set view_relation = api.Relation.create(
+      identifier=generate_alias_name_impl(model.name, config.get('alias', validator=validation.any[basestring]), model),
+      schema=generate_schema_name_impl(target.schema, config.get('schema', validator=validation.any[basestring]), model),
+      database=generate_database_name_impl(target.database, config.get('database', validator=validation.any[basestring]), model),
+      type='view') -%}
+
+    {%- set conflicting_relation = none -%}
+    {%- if target_relation.type == 'view' -%}
+      {%- set table_relation = api.Relation.create(
+          identifier=generate_alias_name_impl(model.name, config.get('file', validator=validation.any[basestring]), model),
+          schema=generate_schema_name_impl(target.root_path, config.get('root_path', validator=validation.any[basestring]), model),
+          database=generate_database_name_impl(target.datalake, config.get('datalake', validator=validation.any[basestring]), model),
+          type='table') -%}
+      {%- set conflicting_relation = adapter.get_relation(database=table_relation.database, schema=table_relation.schema, identifier=table_relation.identifier) -%}
+    {%- elif target_relation.type == 'table' -%}
+      {%- set conflicting_relation = adapter.get_relation(database=view_relation.database, schema=view_relation.schema, identifier=view_relation.identifier) -%}
+    {%- endif -%}
+
+    {%- if conflicting_relation is not none -%}
+      {%- if twin_strategy == 'prevent' -%}
+        -- Prevent strategy -> Drop the conflicting relation
+        {{ adapter.drop_relation(conflicting_relation) }}
+      {%- elif twin_strategy == 'clone' -%}
+        -- Clone strategy -> Create a view selecting from the correct relation
+        {%- set sql_view -%}
+          select *
+          from {{ render_with_format_clause(
+            target_relation.type == 'view' and conflicting_relation or target_relation
+          ) }}
+        {%- endset -%}
+        {% call statement('clone_relation') -%}
+          {{ create_view_as(view_relation, sql_view) }}
+        {%- endcall %} 
+      {%- endif -%}
+    {%- endif -%}    
   {%- endif -%}
 {%- endmacro -%}

--- a/dbt/include/dremio/macros/materializations/twin_strategy.sql
+++ b/dbt/include/dremio/macros/materializations/twin_strategy.sql
@@ -33,7 +33,7 @@ limitations under the License.*/
     {%- set conflicting_relation = adapter.get_relation(database=view_relation.database, schema=view_relation.schema, identifier=view_relation.identifier) -%}
   {%- endif -%}
 
-  {%- if conflicting_relation is not none -%}
+  {%- if conflicting_relation is not none and target_relation.type != conflicting_relation.type -%}
     {%- if twin_strategy == 'prevent' -%}
       -- Prevent strategy -> Drop the conflicting relation
       {{ adapter.drop_relation(conflicting_relation) }}

--- a/dbt/include/dremio/profile_template.yml
+++ b/dbt/include/dremio/profile_template.yml
@@ -54,18 +54,25 @@ prompts:
       use_ssl:
         default: false
         hint: 'use encrypted connection'
-  object_storage_source:
-    default: '$scratch'
-    hint: 'object storage source for seeds, tables, etc. [dbt alias: datalake]'
-  object_storage_path:
-    default: 'no_schema'
-    hint: 'object storage path [dbt alias: schema]'
-  dremio_space:
-    default: '@user'
-    hint: 'space for creating views [dbt alias: database]'
-  dremio_space_folder:
-    default: 'no_schema'
-    hint: 'dremio space folder [dbt alias: root_path]'
+  _choose_storage_configuration_method:
+    enterprise_catalog:
+      enterprise_catalog_namespace:
+        hint: 'enterprise catalog name'
+      enterprise_catalog_folder:
+        hint: 'enterprise catalog folder'
+    sources_and_spaces:
+      object_storage_source:
+        default: '$scratch'
+        hint: 'object storage source for seeds, tables, etc. [dbt alias: datalake]'
+      object_storage_path:
+        default: 'no_schema'
+        hint: 'object storage path [dbt alias: schema]'
+      dremio_space:
+        default: '@user'
+        hint: 'space for creating views [dbt alias: database]'
+      dremio_space_folder:
+        default: 'no_schema'
+        hint: 'dremio space folder [dbt alias: root_path]'
   threads:
     hint: '1 or more'
     type: 'int'


### PR DESCRIPTION
### Summary

Ability to run dbt against Dremio Enterprise Catalogs

### Description

With these changes, we give the users the possibility to choose whether to use **Enterprise Catalog** (EC) or **Space & Source** (S&S) as storage. Internally, using EC just means to have `datalake + root_path` (used for tables storage) and `database + schema` (used for views storage) with the EC path:
- Restructured `dbt init` prompt by introducing new project profile configuration options `enterprise_catalog_namespace` and `enterprise_catalog_folder`, so it's more intuitive for the users
- Disabled twin strategy when an Enterprise Catalog is being used (i.e., when `datalake + root_path` == `database + schema`)

### Test Results

- All CE tests pass

### Changelog

-   [x] Added a summary of what this PR accomplishes to CHANGELOG.md