### PR TITLE
Added features for Nessie branch management

### DIFF
--- a/dbt/include/dremio/macros/adapters/relation.sql
+++ b/dbt/include/dremio/macros/adapters/relation.sql
@@ -26,6 +26,57 @@ limitations under the License.*/
   {%- endcall %}
 {% endmacro %}
 
+{% macro drop_relation_with_branch(relation, branch=none) -%}
+  {% call statement('drop_relation', auto_begin=False) -%}
+    drop {{ relation.type }} if exists {{ relation }}{%- if branch is not none %} at branch {{ branch }}{%- endif %}
+  {%- endcall %}
+{% endmacro %}
+
+{% macro create_branch_statement(relation, branch) -%}
+  {%- set nessie_ref = config.get('nessie_ref', validator=validation.any[string]) -%}
+  {%- if execute -%}
+    {%- set create_branch_sql -%}
+      create branch if not exists {{ branch }}{% if nessie_ref is not none %} at ref {{ nessie_ref }}{% endif %} in {{ relation.database }}
+    {%- endset -%}
+    {%- do run_query(create_branch_sql) -%}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro get_relation_at_branch(database, schema, identifier, branch) -%}
+  {%- if execute -%}
+    {# First, check if the branch exists #}
+    {%- set branch_sql -%}
+      show branches in {{ database }}
+    {%- endset -%}
+    {%- set branch_result = run_query(branch_sql) -%}
+    {%- set branch_exists = False -%}
+    {%- for row in branch_result.rows -%}
+      {%- if row[0] == branch -%}
+        {%- set branch_exists = True -%}
+      {%- endif -%}
+    {%- endfor -%}
+    
+    {# If branch exists, check if table exists in that branch #}
+    {%- set found = False -%}
+    {%- if branch_exists -%}
+      {%- set table_sql -%}
+        show tables in {{ database }}.{{ schema }} at branch {{ branch }}
+      {%- endset -%}
+      {%- set table_result = run_query(table_sql) -%}
+      {%- if table_result.rows | length > 0 -%}
+        {%- for row in table_result.rows -%}
+          {%- if row[1] == identifier -%}
+            {%- set found = True -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+    {%- endif -%}
+    {{ found }}
+  {%- else -%}
+    {{ False }}
+  {%- endif -%}
+{%- endmacro %}
+
 {% macro dremio__rename_relation(from_relation, to_relation) -%}
   {% call statement('rename_relation1/2 - create to_relation from from_relation') -%}
     {{ get_create_table_as_sql(temporary=False, relation=to_relation, sql="select * from " ~ from_relation)}}

--- a/dbt/include/dremio/macros/materializations/table/create_table_as.sql
+++ b/dbt/include/dremio/macros/materializations/table/create_table_as.sql
@@ -34,6 +34,7 @@ limitations under the License.*/
   {{ sql_header if sql_header is not none }}
 
   create table {{ relation }}
+  {{ branch_clause() }}
   {{ partition_method() }} {{ config_cols("partition by") }}
   {{ config_cols("distribute by") }}
   {{ config_cols("localsort by") }}
@@ -64,3 +65,11 @@ limitations under the License.*/
     with single writer
   {%- endif -%}
 {%- endmacro -%}
+
+{%- macro branch_clause() -%}
+  {%- set branch = config.get('branch', validator=validation.any[string]) -%}
+  {%- if branch is not none -%}
+    at branch {{ branch }}
+  {%- endif -%}
+{%- endmacro -%}
+

--- a/dbt/include/dremio/macros/materializations/view/create_view_as.sql
+++ b/dbt/include/dremio/macros/materializations/view/create_view_as.sql
@@ -15,6 +15,7 @@ limitations under the License.*/
 {% macro dremio__create_view_as(relation, sql) -%}
   {% set contract_config = config.get('contract') %}
   {%- set sql_header = config.get('sql_header', none) -%}
+  {%- set branch = config.get('branch', validator=validation.any[string]) -%}
 
   {{ sql_header if sql_header is not none }}
 
@@ -23,6 +24,6 @@ limitations under the License.*/
      {{ get_assert_columns_equivalent(sql) }}
      {% set sql = get_select_subquery(sql) %}
   {% endif %}
-  as {{ sql }}
+  as {{ sql }}{%- if branch is not none %} at branch {{ branch }}{%- endif %}
 
 {%- endmacro %}


### PR DESCRIPTION
### Summary

This PR contains code updates that enable branch management for Nessie source code.

### Description

The changes made allowed us to specify two new configurations:
- `branch`: allows you to specify a branch. If used in a materialized application, it creates the PDS on the specified branch (if the branch doesn't exist, it creates it first). If used in a VDS, however, it creates it from the PDS and the specified branch.
- `nessie_ref`: to be inserted in a materialized application. When present, it creates the new branch from the reference entered; otherwise, if the branch doesn't exist, it is created from main.

### Test Results

- Dremio OSS: **25.1.1**
- Nessie: **0.105.3**
- dbt-dremio: **1.10.0**

I performed the following tests with this stack:
- Created a Nessie-type source on Dremio
- Created a tag named "init" from the Dremio interface
- In the dbt project, I created a `create_pds.sql` file for the PDS to be created on Nessie and a `my_first_query.sql` file for the VDS to be created from the PDS on a Space in the Staging folder:

```create_pds.sql
{{ config(
object_storage_source="mynessiesource",
materialized="table",
branch="test_1"
) }}

SELECT * FROM Samples."samples.dremio.com"."NYC-taxi-trips.csv"
```

```my_first_query.sql
{{ config(
schema = "Staging",
materialized="view",
branch="test_1"
) }}

select *
from {{ ref('create_pds') }}
```

- Starting the project with dbt run correctly creates the `test_1` branch and creates pds and vds with the correct points to the specified branch.

- If we rerun dbt run without changing anything, it checks whether a table with that name already exists in the branch; if it does, it is deleted and then recreated.

- In create_pds.sql, you can also add the `nessie_ref` config, specifying a valid reference (for example, the tag created at the beginning):

```create_pds.sql
{{ config(
object_storage_source="mynessiesource",
materialized="table",
branch="test_2",
nessie_ref="init"
) }}

SELECT * FROM Samples."samples.dremio.com"."NYC-taxi-trips.csv"
```

- This way, the `test_2` branch is created starting from the init tag. This can be useful if we want to create PDSs starting from specific tags/branches/commits.
- From Dremio, I see that the `test_2` branch is correctly created starting from the tag.
- Without specifying `branch` or `nessie_ref` config, the behavior is the usual one.

### Changelog

-   [ ] Added a summary of what this PR accomplishes to CHANGELOG.md

### Contributor License Agreement

<!--- Applicable for non Dremio employees and for first time contributors -->

-   [x] Please make sure you have signed our [Contributor License Agreement](https://www.dremio.com/legal/contributor-agreement/), which enables Dremio to distribute your contribution without restriction.

### Related Issue

- https://github.com/dremio/dbt-dremio/issues/241
