### PR TITLE
Fix ref macro override to support package args and version keyword

### DIFF
--- a/dbt/include/dremio/macros/builtins/builtins.sql
+++ b/dbt/include/dremio/macros/builtins/builtins.sql
@@ -12,10 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.*/
 
-{%- macro ref(model_name, v=None) -%}
-  {%- set relation = builtins.ref(model_name, v=v) -%}
+{%- macro ref(model_name_or_package, model_name=none, v=none, version=none) -%}
+  {%- set effective_version = v if v is not none else version -%}
+  {%- if model_name is not none -%}
+    {%- set relation = builtins.ref(model_name_or_package, model_name, v=effective_version) -%}
+    {%- set _model_name = model_name -%}
+  {%- else -%}
+    {%- set relation = builtins.ref(model_name_or_package, v=effective_version) -%}
+    {%- set _model_name = model_name_or_package -%}
+  {%- endif -%}
   {%- if execute and graph -%}
-    {%- set model = graph.nodes.values() | selectattr("name", "equalto", model_name) | list | first -%}
+    {%- set model = graph.nodes.values() | selectattr("name", "equalto", _model_name) | list | first -%}
     {%- if model.config.materialized == 'reflection' -%}
       {% do exceptions.CompilationError("Reflections cannot be ref()erenced (" ~ relation ~ ")") %}
     {%- endif -%}


### PR DESCRIPTION
### Summary

Fix the `ref` macro override in `builtins.sql` to correctly support all dbt `ref()` calling conventions.

### Description

The current override has the signature `ref(model_name, v=None)`, which breaks two valid dbt calling conventions:

1. **Two-positional-arg form** — `ref('package', 'model')` for cross-package/project refs: the second positional arg was incorrectly interpreted as a version number instead of a model name.
2. **`version` keyword argument** — `ref('model', version=1)` was not accepted at all (only `v=` was supported).

The fix adopts the correct interface per the [dbt docs on builtins overrides](https://docs.getdbt.com/reference/dbt-jinja-functions/builtins#usage):

```diff
-{%- macro ref(model_name, v=None) -%}
-  {%- set relation = builtins.ref(model_name, v=v) -%}
-  {%- if execute and graph -%}
-    {%- set model = graph.nodes.values() | selectattr("name", "equalto", model_name) | list | first -%}
+{%- macro ref(model_name_or_package, model_name=none, v=none, version=none) -%}
+  {%- set effective_version = v if v is not none else version -%}
+  {%- if model_name is not none -%}
+    {%- set relation = builtins.ref(model_name_or_package, model_name, v=effective_version) -%}
+    {%- set _model_name = model_name -%}
+  {%- else -%}
+    {%- set relation = builtins.ref(model_name_or_package, v=effective_version) -%}
+    {%- set _model_name = model_name_or_package -%}
+  {%- endif -%}
+  {%- if execute and graph -%}
+    {%- set model = graph.nodes.values() | selectattr("name", "equalto", _model_name) | list | first -%}
```

Note: the same bug was independently identified and worked around in [elementary-data/elementary](https://github.com/elementary-data/elementary/commit/404708b7a896ef20c3531a05f112c189916dbc6e), which added a local `ref` override specifically to compensate for this dbt-dremio issue.

### Test Results

Manually verified the macro logic against all calling forms:
- `ref('model')` — unchanged behaviour
- `ref('package', 'model')` — now works correctly
- `ref('model', v=1)` — unchanged behaviour  
- `ref('model', version=1)` — now works correctly

### Changelog

- [ ] Added a summary of what this PR accomplishes to CHANGELOG.md

### Contributor License Agreement

- [ ] Please make sure you have signed our [Contributor License Agreement](https://www.dremio.com/legal/contributor-agreement/), which enables Dremio to distribute your contribution without restriction.

### Related Issue

Fixes #232