### PR TITLE
fix(CI): follow redirects when downloading MinIO client

### DIFF
--- a/.github/scripts/install_minio_client.sh
+++ b/.github/scripts/install_minio_client.sh
@@ -4,7 +4,7 @@ set -e
 echo "Installing MinIO Client (mc)..."
 
 {
-    curl -O https://dl.min.io/client/mc/release/linux-amd64/mc &&
+    curl -fLO https://dl.min.io/client/mc/release/linux-amd64/mc &&
     chmod +x mc &&
     mv mc /usr/local/bin/
 } && echo "MinIO Client installed successfully." || {


### PR DESCRIPTION
## Summary

`dl.min.io` now responds with `HTTP/2 302` redirecting to GitHub Releases for the `mc` binary, but `.github/scripts/install_minio_client.sh` used `curl -O` (which does not follow redirects). The result is that the empty 302 response body (141 bytes) is being saved as the `mc` binary, `chmod +x`-ed, and then later steps that invoke `mc` fail with:

```
/usr/local/bin/mc: line 1: a: No such file or directory
##[error]Process completed with exit code 1.
```

This breaks every CI job that depends on MinIO (caching, hooks, functional/adapter/*, etc.).

## Fix

Replace `curl -O` with `curl -fLO`:
- `-L` — follow the 302 redirect to GitHub Releases so the real ~30 MB binary is downloaded.
- `-f` — fail the script on any non-2xx HTTP status, so we get a loud failure instead of silently producing an invalid binary if the download URL changes again in the future.

## Verification

```
$ curl -sI https://dl.min.io/client/mc/release/linux-amd64/mc
HTTP/2 302
location: https://github.com/minio/mc/releases/download/RELEASE.2025-08-13T08-35-41Z/...

$ curl -sIL https://dl.min.io/client/mc/release/linux-amd64/mc | tail -2
HTTP/2 200
content-length: 30535864
```

## Test Plan

- [x] CI on this PR should pass the MinIO install step (was the failure point on recent PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)