### PR TITLE
Avoid creating existing folders during schema setup

### DIFF
--- a/dbt/adapters/dremio/connections.py
+++ b/dbt/adapters/dremio/connections.py
@@ -275,10 +275,13 @@ class DremioConnectionManager(SQLConnectionManager):
         thread_connection = self.get_thread_connection()
         connection = self.open(thread_connection)
         rest_client = connection.handle.get_client()
+        return self._catalog_item_exists([path], rest_client)
+
+    def _catalog_item_exists(self, path_list, rest_client: DremioRestClient):
         try:
             catalog_info = rest_client.get_catalog_item(
                 catalog_id=None,
-                catalog_path=[path],
+                catalog_path=path_list,
             )
             return catalog_info.get("id") is not None
         except DremioNotFoundException:
@@ -434,7 +437,12 @@ class DremioConnectionManager(SQLConnectionManager):
         temp_path_list = [database]
         for folder in schema.split("."):
             temp_path_list.append(folder)
-            folder_json = self._make_new_folder_json(temp_path_list)
+            folder_path = list(temp_path_list)
+            if self._catalog_item_exists(folder_path, rest_client):
+                logger.debug(f"Folder {folder} already exists.")
+                continue
+
+            folder_json = self._make_new_folder_json(folder_path)
             try:
                 rest_client.create_catalog_api(folder_json)
             except DremioAlreadyExistsException:

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -10,10 +10,12 @@
 # limitations under the License.
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from dbt_common.exceptions import DbtRuntimeError
 from dbt.adapters.dremio.api.rest.error import (
     DremioAlreadyExistsException,
+    DremioNotFoundException,
+    DremioPermissionException,
     DremioRequestTimeoutException,
 )
 from dbt.adapters.dremio.connections import DremioConnectionManager
@@ -59,6 +61,10 @@ class TestCreateFolders:
         mgr = DremioConnectionManager.__new__(DremioConnectionManager)
         mgr._make_new_folder_json = MagicMock(return_value="{}")
         rest_client = MagicMock()
+        rest_client.get_catalog_item.side_effect = DremioNotFoundException(
+            msg="Not found:",
+            original_exception="404 Client Error: Not Found",
+        )
         rest_client.create_catalog_api.side_effect = DremioAlreadyExistsException(
             msg="Already exists:",
             original_exception="400 Client Error: Bad Request",
@@ -68,3 +74,56 @@ class TestCreateFolders:
 
         # Both folders in the path attempted; both swallowed
         assert rest_client.create_catalog_api.call_count == 2
+
+    def test_create_folders_skips_existing_folders(self):
+        mgr = DremioConnectionManager.__new__(DremioConnectionManager)
+        mgr._make_new_folder_json = MagicMock(return_value="{}")
+        rest_client = MagicMock()
+        rest_client.get_catalog_item.return_value = {"id": "folder-id"}
+
+        mgr._create_folders("mySource", "staging.subfolder", rest_client)
+
+        rest_client.get_catalog_item.assert_has_calls(
+            [
+                call(catalog_id=None, catalog_path=["mySource", "staging"]),
+                call(
+                    catalog_id=None,
+                    catalog_path=["mySource", "staging", "subfolder"],
+                ),
+            ]
+        )
+        rest_client.create_catalog_api.assert_not_called()
+
+    def test_create_folders_creates_only_missing_folders(self):
+        mgr = DremioConnectionManager.__new__(DremioConnectionManager)
+        mgr._make_new_folder_json = MagicMock(return_value="{}")
+        rest_client = MagicMock()
+        rest_client.get_catalog_item.side_effect = [
+            {"id": "staging-folder"},
+            DremioNotFoundException(
+                msg="Not found:",
+                original_exception="404 Client Error: Not Found",
+            ),
+        ]
+
+        mgr._create_folders("mySource", "staging.subfolder", rest_client)
+
+        rest_client.create_catalog_api.assert_called_once_with("{}")
+
+    def test_create_folders_raises_permission_error_for_missing_folder(self):
+        mgr = DremioConnectionManager.__new__(DremioConnectionManager)
+        mgr._make_new_folder_json = MagicMock(return_value="{}")
+        rest_client = MagicMock()
+        rest_client.get_catalog_item.side_effect = DremioNotFoundException(
+            msg="Not found:",
+            original_exception="404 Client Error: Not Found",
+        )
+        rest_client.create_catalog_api.side_effect = DremioPermissionException(
+            msg="No permission:",
+            original_exception="403 Client Error: Forbidden",
+        )
+
+        with pytest.raises(DremioPermissionException):
+            mgr._create_folders("mySource", "staging", rest_client)
+
+        rest_client.create_catalog_api.assert_called_once_with("{}")


### PR DESCRIPTION
## Summary

- check each Dremio folder path before attempting catalog folder creation
- skip creation for folders that already exist, avoiding unnecessary parent-folder ALTER requirements
- preserve existing already-exists handling and keep permission failures for genuinely missing folders

## Root Cause

`_create_folders` walked every schema path prefix and POSTed `/api/v3/catalog` even when a parent folder already existed. In governed Dremio Software environments, existing admin-managed parent folders can return 403 to create/alter attempts even though the target child folder is usable for model/view creation.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_connection.py tests/unit/test_rest_utils.py`
- `.venv/bin/python -m pytest tests/unit`

## References

- Solves issue #317
