### PR TITLE
Bump dbt-dremio to 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Changes
 
-- Avoided creating existing folders during schema setup.
 - Reenabled `object_storage_path` and `root_path` as config parameters.
+- Fixed CI MinIO client installation by following download redirects.
+- Suppressed Dremio Cloud folder-creation errors when a folder already exists.
+- Avoided creating existing folders during schema setup.
 
 # dbt-dremio v1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes
 
+- Avoided creating existing folders during schema setup.
 - Reenabled `object_storage_path` and `root_path` as config parameters.
 
 # dbt-dremio v1.10.0

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The `dbt-dremio` package contains all of the code enabling dbt to work with [Dre
 
 The dbt-dremio package supports both Dremio Cloud and Dremio Software (versions 22.0 and later).
 
-## dbt-dremio version 1.10.0
+## dbt-dremio version 1.10.1
 
-Version 1.10.0 of the dbt-dremio adapter is compatible with dbt-core versions 1.10.*.
+Version 1.10.1 of the dbt-dremio adapter is compatible with dbt-core versions 1.10.*.
 
 > Prior to version 1.1.0b, dbt-dremio was created and maintained by [Fabrice Etanchaud](https://github.com/fabrice-etanchaud) on [their GitHub repo](https://github.com/fabrice-etanchaud/dbt-dremio). Code for using Dremio REST APIs was originally authored by [Ryan Murray](https://github.com/rymurr). Contributors in this repo are credited for laying the groundwork and maintaining the adapter till version 1.0.6.5. The dbt-dremio adapter is maintained and distributed by Dremio starting with version 1.1.0b.
 
 ## Getting started
 
 -   [Install dbt-dremio](https://docs.getdbt.com/reference/warehouse-setups/dremio-setup)
-    -   Version 1.10.0 of dbt-dremio requires dbt-core >= 1.10.*.
+    -   Version 1.10.1 of dbt-dremio requires dbt-core >= 1.10.*.
 -   Read the [introduction](https://docs.getdbt.com/docs/introduction/) and [viewpoint](https://docs.getdbt.com/docs/about/viewpoint/)
 
 ## Join the dbt Community

--- a/dbt/adapters/dremio/__version__.py
+++ b/dbt/adapters/dremio/__version__.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.10.0"
+version = "1.10.1"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ README
 
 package_name = "dbt-dremio"
 
-package_version = "1.10.0"
+package_version = "1.10.1"
 
 description = """The Dremio adapter plugin for dbt"""
 


### PR DESCRIPTION
## Summary

- bump the dbt-dremio package version from 1.10.0 to 1.10.1
- update the adapter __version__ metadata
- update README current-release references
- complete the v1.10.1 changelog entries for commits merged after v1.10.0