### PR TITLE
Fix infinite hang when Dremio job is cancelled (CANCELED vs CANCELLED)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed CI MinIO client installation by following download redirects.
 - Suppressed Dremio Cloud folder-creation errors when a folder already exists.
 - Avoided creating existing folders during schema setup.
+- Fix infinite hang on cancelled Dremio jobs by handling the CANCELED job state (single L)
 
 # dbt-dremio v1.10.0
 

--- a/dbt/adapters/dremio/api/cursor.py
+++ b/dbt/adapters/dremio/api/cursor.py
@@ -115,7 +115,7 @@ class DremioCursor:
     def _populate_rowcount(self):
         if self.closed:
             raise Exception("CursorClosed")
-        # keep checking job status until status is one of COMPLETE, CANCELLED or FAILED
+        # keep checking job status until status is one of COMPLETED, CANCELED or FAILED
         # map job results to AdapterResponse
         job_id = self._job_id
 
@@ -132,7 +132,14 @@ class DremioCursor:
                 error_message = job_status_response["errorMessage"]
                 raise Exception(f"ERROR: {error_message}")
 
-            if job_status_state == "CANCELLED":
+            if job_status_state in ("CANCELED", "CANCELLED"):
+                cancellation_reason = job_status_response.get(
+                    "cancellationReason"
+                )
+                if cancellation_reason:
+                    raise Exception(
+                        f"Job was cancelled: {cancellation_reason}"
+                    )
                 raise Exception("Job was cancelled")
 
             if job_status_state == "COMPLETED":


### PR DESCRIPTION
### Summary

Fix infinite hang on cancelled Dremio jobs by handling the CANCELED job state (single L)

### Description

[DremioCursor._populate_rowcount()] polls Dremio job status in a while True loop and treats FAILED, COMPLETED, and CANCELLED (double L) as terminal states. However, Dremio's REST API returns the American spelling CANCELED (single L) for cancelled jobs — whether cancelled by a user, by the engine (e.g. low memory), or by hitting a workload-management queue timeout.

Because the loop only checked for CANCELLED, a real CANCELED job never matched any terminal branch, so the poller looped forever. dbt never raised, never failed, and never returned — the run hung indefinitely (and, for orchestrators like Dagster/Airflow, the step neither failed nor cancelled). This is reproducible by letting a query exceed its WLM queue timeout, or by cancelling the job from the Dremio Jobs UI.

**Reference** — Dremio Job API jobState enum (final states are COMPLETED, CANCELED, FAILED): [https://docs.dremio.com/cloud/reference/api/job/](vscode-file://vscode-app/c:/Users/shanmugapriya.c/AppData/Local/Programs/Microsoft%20VS%20Code/1b50d58d73/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Changes in [cursor.py]:**

Match both CANCELED and CANCELLED as terminal cancellation states and raise (previously only CANCELLED).
Surface Dremio's cancellationReason in the error message when present (e.g. queue-timeout reason), falling back to "Job was cancelled" for backward compatibility with the existing message.
Updated the stale loop comment (COMPLETE, CANCELLED → COMPLETED, CANCELED).
The fix is intentionally minimal and preserves the existing exception type/message contract.

### Test Results

All tests are passing

### Changelog

-   [X] Added a summary of what this PR accomplishes to CHANGELOG.md

### Contributor License Agreement

<!--- Applicable for non Dremio employees and for first time contributors -->

-   [X] Please make sure you have signed our [Contributor License Agreement](https://www.dremio.com/legal/contributor-agreement/), which enables Dremio to distribute your contribution without restriction.

### Related Issue

NA
